### PR TITLE
use mondoo download service for windows powershell scripts

### DIFF
--- a/download.ps1
+++ b/download.ps1
@@ -1,80 +1,58 @@
 #Requires -Version 5
 
-# Automatic Mondoo downloader to be used with
-# Set-ExecutionPolicy RemoteSigned -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex (new-object net.webclient).downloadstring('https://mondoo.com/download.ps1')
+<#
+    .SYNOPSIS
+    # Automatic Mondoo downloader to be used with
+    # [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex (new-object net.webclient).downloadstring('https://mondoo.com/download.ps1')
 
-function fail($msg, [int] $exit_code=1) { Write-Host $msg -f red; exit $exit_code }
-function info($msg) {  Write-Host $msg -f white }
-function success($msg) { Write-Host $msg -f darkgreen }
-function purple($msg) { Write-Host $msg -f magenta }
+    .PARAMETER Product
+    Set 'cnspec' (default) to download and extract the 'zip', possible values: 'cnquery', 'cnspec', 'mondoo'
+    .PARAMETER Version
+    If provided, tries to download the specific version instead of the latest
+    .EXAMPLE
+    download.ps1 -Product cnspec
+    download.ps1 -Version 6.14.0
+    download.ps1 -Path 'C:\Users\Administrator\mondoo'
+#>
 
-purple "Mondoo Binary Download Script"
-purple "
-                        .-.            
-                        : :            
-,-.,-.,-. .--. ,-.,-. .-`' : .--.  .--.
-: ,. ,. :`' .; :: ,. :`' .; :`' .; :`' .; :
-:_;:_;:_;``.__.`':_;:_;``.__.`'``.__.`'``.__.
-"
-                 
-info "Welcome to the Mondoo Binary Download Script. It downloads the Mondoo binary for
-Windows into $ENV:UserProfile\mondoo and adds the path to the user's environment PATH. If 
-you are experiencing any issues, please do not hesitate to reach out: 
+Param(
+      [string]   $Product = 'cnspec',
+      [string]   $Path = '',
+      [string]   $Version = ''
+  )
 
-  * Mondoo Community GitHub Discussions https://github.com/orgs/mondoohq/discussions
-
-This script source is available at: https://github.com/mondoohq/client
-"
-
-# Any subsequent commands which fails will stop the execution of the shell script
-$previous_erroractionpreference = $erroractionpreference
-$erroractionpreference = 'stop'
-
-# verify powershell pre-conditions
-if(($PSVersionTable.PSVersion.Major) -lt 5) {
-  fail "
-The install script requires PowerShell 5 or later.
-To upgrade PowerShell visit https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell
-"
+function fail($msg) {
+  Write-Error -ErrorAction Stop -Message $msg
 }
 
-# show notification to change execution policy:
-if((Get-ExecutionPolicy) -gt 'RemoteSigned' -or (Get-ExecutionPolicy) -eq 'ByPass') {
-  fail "
-PowerShell requires an execution policy of 'RemoteSigned'. Please change the policy by running:
-Set-ExecutionPolicy RemoteSigned -scope CurrentUser
-"
+function info($msg) {
+  $host.ui.RawUI.ForegroundColor = "white"
+  Write-Output $msg
 }
 
-# we only support x86_64 at this point, stop if we got arm
-if ($env:PROCESSOR_ARCHITECTURE -ne 'AMD64') {
-  fail "
-Your processor architecture $env:PROCESSOR_ARCHITECTURE is not supported yet. Contact hello@mondoo.com or join the Mondoo Community GitHub Discussions https://github.com/orgs/mondoohq/discussions
-"
+function success($msg) {
+  $host.ui.RawUI.ForegroundColor = "darkgreen"
+  Write-Output $msg
+}
+
+function purple($msg) {
+  $host.ui.RawUI.ForegroundColor = "magenta"
+  Write-Output $msg
 }
 
 function Get-UserAgent() {
-    return "MondooDownloadScript/1.0 (+https://mondoo.com/) PowerShell/$($PSVersionTable.PSVersion.Major).$($PSVersionTable.PSVersion.Minor) (Windows NT $([System.Environment]::OSVersion.Version.Major).$([System.Environment]::OSVersion.Version.Minor);$PSEdition)"
+  return "MondooDownloadScript/1.0 (+https://mondoo.com/) PowerShell/$($PSVersionTable.PSVersion.Major).$($PSVersionTable.PSVersion.Minor) (Windows NT $([System.Environment]::OSVersion.Version.Major).$([System.Environment]::OSVersion.Version.Minor);$PSEdition)"
 }
 
 function download($url,$to) {
-    $wc = New-Object Net.Webclient
-    $wc.Headers.Add('User-Agent', (Get-UserAgent))
-    $wc.downloadFile($url,$to)
-}
-
-function determine_latest() {
-  $url = 'https://releases.mondoo.com/mondoo/latest.json'
   $wc = New-Object Net.Webclient
   $wc.Headers.Add('User-Agent', (Get-UserAgent))
-  $latest = $wc.DownloadString($url) | ConvertFrom-Json 
-  $entry = $latest.files | where { $_.platform -eq "windows" -and $_.filename -match 'zip$' }
-  $entry.filename
+  $wc.downloadFile($url,$to)
 }
 
 function getenv($name,$global) {
-    $target = 'User'; if($global) {$target = 'Machine'}
-    [System.Environment]::GetEnvironmentVariable($name,$target)
+  $target = 'User'; if($global) {$target = 'Machine'}
+  [System.Environment]::GetEnvironmentVariable($name,$target)
 }
 
 function setenv($name,$value,$global) {
@@ -82,37 +60,99 @@ function setenv($name,$value,$global) {
   [System.Environment]::SetEnvironmentVariable($name,$value,$target)
 }
 
-$dir = Get-Location
+purple "$Product Binary Download Script"
+purple "
+                        .-.
+                        : :
+,-.,-.,-. .--. ,-.,-. .-`' : .--.  .--.
+: ,. ,. :`' .; :: ,. :`' .; :`' .; :`' .; :
+:_;:_;:_;``.__.`':_;:_;``.__.`'``.__.`'``.__.
+"
 
-# manual override
-# $version = '5.2.0'
-# $arch = 'amd64'
-# $releaseurl = "https://releases.mondoo.com/mondoo/${version}/mondoo_${version}_windows_${arch}.zip"
+info "Welcome to the $Product Binary Download Script. It downloads the $Product binary for
+Windows into $ENV:UserProfile\$Product and adds the path to the user's environment PATH. If
+you are experiencing any issues, please do not hesitate to reach out:
 
-# automatic
-$releaseurl = determine_latest
+  * Mondoo Community GitHub Discussions https://github.com/orgs/mondoohq/discussions
+
+This script source is available at: https://github.com/mondoohq/installer
+"
+
+# Any subsequent commands which fails will stop the execution of the shell script
+$previous_erroractionpreference = $erroractionpreference
+$erroractionpreference = 'stop'
+
+# verify powershell pre-conditions
+If (($PSVersionTable.PSVersion.Major) -lt 5) {
+  fail "
+The install script requires PowerShell 5 or later.
+To upgrade PowerShell visit https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell
+"
+}
+
+# show notification to change execution policy:
+If ((Get-ExecutionPolicy) -gt 'RemoteSigned' -or (Get-ExecutionPolicy) -eq 'ByPass') {
+  fail "
+PowerShell requires an execution policy of 'RemoteSigned'. Please change the policy by running:
+Set-ExecutionPolicy RemoteSigned -scope CurrentUser
+"
+}
+
+# we only support x86_64 at this point, stop if we got arm
+If ($env:PROCESSOR_ARCHITECTURE -ne 'AMD64') {
+  fail "
+Your processor architecture $env:PROCESSOR_ARCHITECTURE is not supported yet. Contact hello@mondoo.com or join the Mondoo Community GitHub Discussions https://github.com/orgs/mondoohq/discussions
+"
+}
+
+info "Arguments:"
+  info ("  Product:           {0}" -f $Product)
+  info ("  Path:              {0}" -f $Path)
+  info ("  Version:           {0}" -f $Version)
+  info ""
+
+# set download location
+If ([string]::IsNullOrEmpty($Path)) {
+  $path = Get-Location
+} Else {
+  # Check if Path exists
+  $path = $Path.trim('\')
+  If (!(Test-Path $path)) {New-Item -Path $path -ItemType Directory}
+}
+
+$filetype = 'zip'
+$arch = 'amd64'
+$releaseurl = ''
+
+If ([string]::IsNullOrEmpty($version)) {
+    # latest release
+    $releaseurl = "https://install.mondoo.com/package/${product}/windows/${arch}/${filetype}/latest/download"
+  } Else {
+    # specific version
+    $releaseurl = "https://install.mondoo.com/package/${product}/windows/${arch}/${filetype}/${Version}/download"
+  }
 
 # download windows binary zip
-$releasezipfile = "$dir\mondoo.zip"
-info " * Downloading mondoo from $releaseurl to $releasezipfile"
-download $releaseurl $releasezipfile
+$downloadlocation = "$path\$Product.$filetype"
+info " * Downloading $Product from $releaseurl to $downloadlocation"
+download $releaseurl $downloadlocation
 
 info ' * Extracting zip...'
 # remove older version if it is still there
-Remove-Item "$dir\mondoo.exe" -Force -ErrorAction Ignore
+Remove-Item "$path\$Product.exe" -Force -ErrorAction Ignore
 Add-Type -Assembly "System.IO.Compression.FileSystem"
-[IO.Compression.ZipFile]::ExtractToDirectory($releasezipfile,$dir)
-Remove-Item $releasezipfile -Force
+[IO.Compression.ZipFile]::ExtractToDirectory($downloadlocation,$path)
+Remove-Item $downloadlocation -Force
 
-success ' * Mondoo was downloaded successfully!'
+success " * $Product was downloaded successfully!"
 
 # Display final message
-info "Thank you for downloading Mondoo!"
+info "Thank you for downloading $Product!"
 info "
-If you need support, contact hello@mondoo.com or join the Mondoo Community on GitHub Discussion:
+  If you have any questions, please come join us in our Mondoo Community on GitHub Discussions:
 
-  * https://github.com/orgs/mondoohq/discussions
-"
+    * https://github.com/orgs/mondoohq/discussions
+  "
 
 # reset erroractionpreference
 $erroractionpreference = $previous_erroractionpreference


### PR DESCRIPTION
`install.ps1`:

- download and install only it the mondoo version differs from the installed version
- use the mondoo download service

`download.ps1`:

- use the new download service
- added params for downloading a specific version of mondoo, cnspec or cnquery


Signed-off-by: Patrick Münch <patrick.muench1111@gmail.com>