### PR TITLE
⭐️ add powershell module

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # Declare files that will always have CRLF line endings on checkout
 *.ps1 text eol=crlf
+*.psm1 text eol=crlf
+*.psd1 text eol=crlf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,3 +69,4 @@ jobs:
           git config --global user.name "Mondoo Tools"
           git commit -m "Update VERSION to $VERSION"
           git push -f
+  

--- a/.github/workflows/release_pwsh_module.yml
+++ b/.github/workflows/release_pwsh_module.yml
@@ -1,0 +1,20 @@
+name: Release Powershell Module
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: windows-2022
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          ref: "powershell-module" # Test, remove once tested successfully
+      - name: Publish Powershell Module
+        shell: powershell
+        env:
+          NUGETAPIKEY: ${{ secrets.NUGETAPIKEY }}
+        run: |
+          Test-ModuleManifest -Path ".\powershell\Mondoo.Installer\Mondoo.Installer.psd1"
+          Publish-Module -Path .\powershell\Mondoo.Installer -NuGetApiKey $env:NUGETAPIKEY

--- a/.github/workflows/sign_powershell.yml
+++ b/.github/workflows/sign_powershell.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - '**.ps1'
       - '**.psm1'
+      - '**.psd1'
 
 jobs:
   sign_scripts:
@@ -44,6 +45,13 @@ jobs:
           [IO.File]::WriteAllLines($filename, $content)
           Set-AuthenticodeSignature -Certificate (Get-PfxCertificate -FilePath .\mondoo_code_signing_cert.pfx) -FilePath $filename -TimestampServer 'http://timestamp.digicert.com' -HashAlgorithm 'SHA256'
           (Get-AuthenticodeSignature "$filename").Status -eq 'Valid'
+
+          # sign Mondoo.Installer.psd1 and ensure proper encoding as UTF8 NoBOM
+          $filename = './powershell/Mondoo.Installer/Mondoo.Installer.psd1'
+          $content = Get-Content $filename
+          [IO.File]::WriteAllLines($filename, $content)
+          Set-AuthenticodeSignature -Certificate (Get-PfxCertificate -FilePath .\mondoo_code_signing_cert.pfx) -FilePath $filename -TimestampServer 'http://timestamp.digicert.com' -HashAlgorithm 'SHA256'
+          (Get-AuthenticodeSignature "$filename").Status -eq 'Valid'
           
           # ensure windows line-feed
           git config --global core.autocrlf true 
@@ -53,5 +61,6 @@ jobs:
           git add install.ps1
           git add download.ps1
           git add powershell/Mondoo.Installer/Mondoo.Installer.psm1
+          git add powershell/Mondoo.Installer/Mondoo.Installer.psd1
           git commit -m "Sign powershell scripts"
           git push

--- a/.github/workflows/sign_powershell.yml
+++ b/.github/workflows/sign_powershell.yml
@@ -7,6 +7,7 @@ on:
       - master
     paths:
       - '**.ps1'
+      - '**.psm1'
 
 jobs:
   sign_scripts:
@@ -37,6 +38,12 @@ jobs:
           Set-AuthenticodeSignature -Certificate (Get-PfxCertificate -FilePath .\mondoo_code_signing_cert.pfx) -FilePath $filename -TimestampServer 'http://timestamp.digicert.com' -HashAlgorithm 'SHA256'
           (Get-AuthenticodeSignature "$filename").Status -eq 'Valid'
 
+          # sign Mondoo.Installer.psm1 and ensure proper encoding as UTF8 NoBOM
+          $filename = './powershell/Mondoo.Installer/Mondoo.Installer.psm1'
+          $content = Get-Content $filename
+          [IO.File]::WriteAllLines($filename, $content)
+          Set-AuthenticodeSignature -Certificate (Get-PfxCertificate -FilePath .\mondoo_code_signing_cert.pfx) -FilePath $filename -TimestampServer 'http://timestamp.digicert.com' -HashAlgorithm 'SHA256'
+          (Get-AuthenticodeSignature "$filename").Status -eq 'Valid'
           
           # ensure windows line-feed
           git config --global core.autocrlf true 
@@ -45,5 +52,6 @@ jobs:
           git config --global user.name "Mondoo Tools"
           git add install.ps1
           git add download.ps1
+          git add powershell/Mondoo.Installer/Mondoo.Installer.psm1
           git commit -m "Sign powershell scripts"
           git push

--- a/Makefile
+++ b/Makefile
@@ -58,3 +58,5 @@ test/powershell:
 	pwsh -Command "Install-Module -Name PSScriptAnalyzer"
 	pwsh -Command "Invoke-ScriptAnalyzer -Path .\install.ps1"
 	pwsh -Command "Invoke-ScriptAnalyzer -Path .\download.ps1"
+	pwsh -Command "Invoke-ScriptAnalyzer -Path .\powershell/Mondoo.Installer/Mondoo.Installer.psm1"
+	pwsh -Command "Test-ModuleManifest -Path ".\powershell\Mondoo.Installer\Mondoo.Installer.psd1""

--- a/powershell/Mondoo.Installer/Mondoo.Installer.psd1
+++ b/powershell/Mondoo.Installer/Mondoo.Installer.psd1
@@ -1,0 +1,122 @@
+# Copyright (c) Mondoo, Inc. All rights reserved.
+# Licensed under the Apache 2 License.
+
+@{
+
+    # Script module or binary module file associated with this manifest.
+    RootModule = './Mondoo.Installer.psm1'
+    
+    # Version number of this module.
+    ModuleVersion = '1.0.2'
+    
+    # Supported PSEditions
+    # CompatiblePSEditions = @()
+    
+    # ID used to uniquely identify this module
+    GUID = '53ec5a21-43bd-4279-8e23-59e8bc9802e6'
+    
+    # Author of this module
+    Author = 'Mondoo, Inc'
+    
+    # Company or vendor of this module
+    CompanyName = 'Mondoo, Inc'
+    
+    # Copyright statement for this module
+    Copyright = 'Copyright Mondoo, Inc. All rights reserved.'
+    
+    # Description of the functionality provided by this module
+    Description = 'The Mondoo.Installer module makes it easier to install and update Mondoo packages. Scripts for Mondoo.
+You can use a single command ''Install-Mondoo'' to install cnquery and cnspec packages.'
+    
+    # Minimum version of the Windows PowerShell engine required by this module
+    PowerShellVersion = '5.1'
+    
+    # Name of the Windows PowerShell host required by this module
+    # PowerShellHostName = ''
+    
+    # Minimum version of the Windows PowerShell host required by this module
+    # PowerShellHostVersion = ''
+    
+    # Minimum version of Microsoft .NET Framework required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
+    # DotNetFrameworkVersion = ''
+    
+    # Minimum version of the common language runtime (CLR) required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
+    # CLRVersion = ''
+    
+    # Processor architecture (None, X86, Amd64) required by this module
+    # ProcessorArchitecture = ''
+    
+    # Modules that must be imported into the global environment prior to importing this module
+    # RequiredModules = @()
+    
+    # Assemblies that must be loaded prior to importing this module
+    # RequiredAssemblies = @()
+    
+    # Script files (.ps1) that are run in the caller's environment prior to importing this module.
+    # ScriptsToProcess = @()
+    
+    # Type files (.ps1xml) to be loaded when importing this module
+    # TypesToProcess = @()
+    
+    # Format files (.ps1xml) to be loaded when importing this module
+    # FormatsToProcess = @()
+    
+    # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
+    # NestedModules = @()
+    
+    # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
+    FunctionsToExport = @(
+        'Install-Mondoo'
+    )
+    
+    # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
+    CmdletsToExport = @()
+    
+    # Variables to export from this module
+    VariablesToExport = '*'
+    
+    # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
+    AliasesToExport = @()
+    
+    # DSC resources to export from this module
+    # DscResourcesToExport = @()
+    
+    # List of all modules packaged with this module
+    # ModuleList = @()
+    
+    # List of all files packaged with this module
+    # FileList = @()
+    
+    # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
+    PrivateData = @{
+    
+        PSData = @{
+    
+            # Tags applied to this module. These help with module discovery in online galleries.
+            Tags = @('Mondoo', 'cloud', 'Windows', 'security', 'vulnerability', 'Azure')
+    
+            # A URL to the license for this module.
+            # LicenseUri = ''
+    
+            # A URL to the main website for this project.
+            ProjectUri = 'https://github.com/mondoohq/installer/'
+    
+            # A URL to an icon representing this module.
+            IconUri = 'https://avatars.githubusercontent.com/u/99198514?s=200&v=4'
+    
+            # ReleaseNotes of this module
+            # ReleaseNotes = ''
+    
+        } # End of PSData hashtable
+    
+    } # End of PrivateData hashtable
+    
+    # HelpInfo URI of this module
+    # HelpInfoURI = ''
+    
+    # Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
+    # DefaultCommandPrefix = ''
+    
+    }
+    
+    

--- a/powershell/Mondoo.Installer/Mondoo.Installer.psm1
+++ b/powershell/Mondoo.Installer/Mondoo.Installer.psm1
@@ -1,0 +1,534 @@
+#Requires -Version 5
+#Requires -RunAsAdministrator
+<#
+    .SYNOPSIS
+    This PowerShell script installs the latest Mondoo agent on windows. Usage:
+    Set-ExecutionPolicy RemoteSigned -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://install.mondoo.com/ps1')); Install-Mondoo;
+
+    .PARAMETER RegistrationToken
+    The registration token for your mondoo installation. See our docs if you do not
+    have one: https://mondoo.com/docs/server/registration
+    .PARAMETER DownloadType
+    Set 'msi' (default) to download the package or 'zip' for the agent binary instead
+    .PARAMETER Version
+    If provided, tries to download the specific version instead of the latest
+    .EXAMPLE
+    Import-Module ./install.ps1; Install-Mondoo -RegistrationToken 'INSERTKEYHERE'
+    Import-Module ./install.ps1; Install-Mondoo -Version 6.14.0
+    Import-Module ./install.ps1; Install-Mondoo -Proxy 1.1.1.1:3128
+    Import-Module ./install.ps1; Install-Mondoo -Service enable
+    Import-Module ./install.ps1; Install-Mondoo -UpdateTask enable -Time 12:00 -Interval 3
+    Import-Module ./install.ps1; Install-Mondoo -Product cnspec
+    Import-Module ./install.ps1; Install-Mondoo -Path 'C:\Program Files\Mondoo\'
+#>
+function Install-Mondoo {
+  [CmdletBinding()]
+  Param(
+      [string]   $Product = 'mondoo',
+      [string]   $DownloadType = 'msi',
+      [string]   $Path = 'C:\Program Files\Mondoo\',
+      [string]   $Version = '',
+      [string]   $RegistrationToken = '',
+      [string]   $Proxy = '',
+      [string]   $Service = '',
+      [string]   $UpdateTask = '',
+      [string]   $Time = '',
+      [string]   $Interval = '',
+      [string]   $taskname = "MondooUpdater",
+      [string]   $taskpath = "Mondoo"
+  )
+  Process {
+
+  function fail($msg) {
+    Write-Error -ErrorAction Stop -Message $msg
+  }
+
+  function info($msg) {
+    $host.ui.RawUI.ForegroundColor = "white"
+    Write-Output $msg
+  }
+
+  function success($msg) {
+    $host.ui.RawUI.ForegroundColor = "darkgreen"
+    Write-Output $msg
+  }
+
+  function purple($msg) {
+    $host.ui.RawUI.ForegroundColor = "magenta"
+    Write-Output $msg
+  }
+
+  function Get-UserAgent() {
+    return "MondooInstallScript/1.0 (+https://mondoo.com/) PowerShell/$($PSVersionTable.PSVersion.Major).$($PSVersionTable.PSVersion.Minor) (Windows NT $([System.Environment]::OSVersion.Version.Major).$([System.Environment]::OSVersion.Version.Minor);$PSEdition)"
+  }
+
+  function download($url,$to) {
+    $wc = New-Object Net.Webclient
+    If(![string]::IsNullOrEmpty($Proxy)) {
+      $wc.proxy = New-Object System.Net.WebProxy($Proxy)
+    }
+    $wc.Headers.Add('User-Agent', (Get-UserAgent))
+    $wc.downloadFile($url,$to)
+  }
+
+  function determine_latest {
+    Param
+    (
+        [Parameter(Mandatory)]
+        [string[]]$product,
+        [Parameter(Mandatory)]
+        [string[]]$filetype,
+        [Parameter(Mandatory)]
+        [string[]]$arch
+    )
+    If([string]::IsNullOrEmpty($filetype)) {
+      $filetype = [regex]::escape('msi')
+    }
+    $url_version = "https://install.mondoo.com/package/${product}/windows/${arch}/${filetype}/latest/version"
+    $wc = New-Object Net.Webclient
+    If(![string]::IsNullOrEmpty($Proxy)) {
+      $wc.proxy = New-Object System.Net.WebProxy($Proxy)
+    }
+    $wc.Headers.Add('User-Agent', (Get-UserAgent))
+    $wc.DownloadString($url_version)
+  }
+
+  function getenv($name,$global) {
+    $target = 'User'; if($global) {$target = 'Machine'}
+    [System.Environment]::GetEnvironmentVariable($name,$target)
+  }
+
+  function setenv($name,$value,$global) {
+    $target = 'User'; if($global) {$target = 'Machine'}
+    [System.Environment]::SetEnvironmentVariable($name,$value,$target)
+  }
+
+  function enable_service() {
+    info "Set Mondoo Client to run as a service automatically at startup and start the service"
+    Set-Service -Name mondoo -Status Running -StartupType Automatic
+    If(![string]::IsNullOrEmpty($Proxy)) {
+      # set register key for Mondoo Service to use proxy for internet connection
+      reg add hklm\SYSTEM\CurrentControlSet\Services\Mondoo /v Environment /t REG_MULTI_SZ /d "https_proxy=$Proxy" /f
+    }
+    If(((Get-Service -Name Mondoo).Status -eq 'Running') -and ((Get-Service -Name Mondoo).StartType -eq 'Automatic') ) {
+      success "* Mondoo Service is running and start type is automatic"
+    } Else {
+      fail "Mondoo service configuration failed"
+    }
+  }
+
+  function NewScheduledTaskFolder($taskpath)
+  {
+      $ErrorActionPreference = "stop"
+      $scheduleObject = New-Object -ComObject schedule.service
+      $scheduleObject.connect()
+      $rootFolder = $scheduleObject.GetFolder("\")
+      Try { $null = $scheduleObject.GetFolder($taskpath) }
+      Catch { $null = $rootFolder.CreateFolder($taskpath) }
+      Finally { $ErrorActionPreference = "continue" }
+  }
+
+  function CreateAndRegisterMondooUpdaterTask($taskname, $taskpath)
+  {
+    info "Create and register the Mondoo update task"
+    NewScheduledTaskFolder $taskpath
+
+    $taskArgument = '-NoProfile -WindowStyle Hidden -ExecutionPolicy RemoteSigned -Command &{ [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $wc = New-Object Net.Webclient; '
+
+    If (![string]::IsNullOrEmpty($Proxy)) {
+      # Add proxy config to scheduling task
+      $taskArgument = $taskArgument += '$wc.proxy = New-Object System.Net.WebProxy(\"' + $Proxy + '\"); '
+    }
+
+    $taskArgument = $taskArgument += 'iex ($wc.DownloadString(\"https://install.mondoo.com/ps1\")); Install-Mondoo '
+
+    # Set product name in scheduling task
+    $taskArgument = $taskArgument += '-Product ' + $Product + ' '
+
+    # Set Path in scheduling task
+    $taskArgument = $taskArgument += '-Path \"' + $Path + '\" '
+
+    # Service enabled
+    If ($Service.ToLower() -eq 'enable' -and $Product.ToLower() -eq 'mondoo') {
+      $taskArgument = $taskArgument += '-Service enable '
+    }
+
+    # Proxy enabled
+    If (![string]::IsNullOrEmpty($Proxy)) {
+      $taskArgument = $taskArgument += '-Proxy ' + $Proxy + ' '
+    }
+
+    # Recreate scheduling task
+    If ($UpdateTask.ToLower() -eq 'enable') {
+      $taskArgument = $taskArgument += '-UpdateTask enable -Time ' + $Time + ' -Interval ' + $Interval +' '
+    }
+
+    $taskArgument = $taskArgument += ';}'
+
+    $action = New-ScheduledTaskAction -Execute 'Powershell.exe' -Argument $taskArgument
+    $trigger =  @(
+      $(New-ScheduledTaskTrigger -Daily -DaysInterval $Interval -At $Time)
+    )
+    $principal = New-ScheduledTaskPrincipal -GroupId "NT AUTHORITY\SYSTEM" -RunLevel Highest
+    Register-ScheduledTask -Action $action -Trigger $trigger -TaskName $taskname -Description "$Product Updater Task" -TaskPath $taskpath -Principal $principal
+
+    If (Get-ScheduledTask -TaskName $taskname -EA 0)
+    {
+        success "* $Product Updater Task installed"
+    } Else {
+      fail "Installation of $Product Updater Task failed"
+    }
+  }
+
+  purple "Mondoo Windows Installer Script"
+  purple "
+                          .-.
+                          : :
+  ,-.,-.,-. .--. ,-.,-. .-`' : .--.  .--.
+  : ,. ,. :`' .; :: ,. :`' .; :`' .; :`' .; :
+  :_;:_;:_;``.__.`':_;:_;``.__.`'``.__.`'``.__.
+  "
+
+  info "Welcome to the $Product Install Script. It downloads the $Product binary for
+  Windows into $ENV:UserProfile\$Product and adds the path to the user's environment PATH. If
+  you are experiencing any issues, please do not hesitate to reach out:
+
+    * Mondoo Community GitHub Discussions https://github.com/orgs/mondoohq/discussions
+
+  This script source is available at: https://github.com/mondoohq/installer
+  "
+
+  # Any subsequent commands which fails will stop the execution of the shell script
+  $previous_erroractionpreference = $erroractionpreference
+  $erroractionpreference = 'stop'
+
+  # verify powershell pre-conditions
+  If (($PSVersionTable.PSVersion.Major) -lt 5) {
+    fail "
+  The install script requires PowerShell 5 or later.
+  To upgrade PowerShell visit https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell
+  "
+  }
+
+  # we only support x86_64 at this point, stop if we got arm
+  If ($env:PROCESSOR_ARCHITECTURE -ne 'AMD64' -and -not ($env:PROCESSOR_ARCHITECTURE -eq "x86" -and [Environment]::Is64BitOperatingSystem)) {
+    fail "
+  Your processor architecture $env:PROCESSOR_ARCHITECTURE is not supported yet. Please come join us in
+  our Mondoo Community GitHub Discussions https://github.com/orgs/mondoohq/discussions or email us at hello@mondoo.com
+  "
+  }
+
+  info "Arguments:"
+  info ("  Product:           {0}" -f $Product)
+  info ("  RegistrationToken: {0}" -f $RegistrationToken)
+  info ("  DownloadType:      {0}" -f $DownloadType)
+  info ("  Path:              {0}" -f $Path)
+  info ("  Version:           {0}" -f $Version)
+  info ("  Proxy:             {0}" -f $Proxy)
+  info ("  Service:           {0}" -f $Service)
+  info ("  UpdateTask:        {0}" -f $UpdateTask)
+  info ("  Time:              {0}" -f $Time)
+  info ("  Interval:          {0}" -f $Interval)
+  info ""
+
+  # determine download url
+  $filetype = $DownloadType
+  # cnquery and cnspec only ship as zip
+  If ($product -ne 'mondoo') {
+    $filetype = 'zip'
+  }
+  # get the installed mondoo version
+  $installed_version = Get-CIMInstance -Class Win32_Product | Where-Object vendor -eq "Mondoo, Inc."
+
+  $arch = 'amd64'
+  $releaseurl = ''
+  $version = $Version
+
+  If ([string]::IsNullOrEmpty($Version)) {
+    # latest release
+    $version = determine_latest -product $Product -filetype $filetype -arch $arch
+    $releaseurl = "https://install.mondoo.com/package/${Product}/windows/${arch}/${filetype}/latest/download"
+  } Else {
+    # specific version
+    $releaseurl = "https://install.mondoo.com/package/${Product}/windows/${arch}/${filetype}/${version}/download"
+  }
+
+  If ($version -ne  $installed_version.version) {
+    # Check if Path exists
+    $Path = $Path.trim('\')
+    If (!(Test-Path $Path)) {New-Item -Path $Path -ItemType Directory}
+
+    # download windows binary zip/msi
+    $downloadlocation = "$Path\$Product.$filetype"
+    info " * Downloading $Product from $releaseurl to $downloadlocation"
+    download $releaseurl $downloadlocation
+
+    If ($filetype -eq 'zip') {
+      info ' * Extracting zip...'
+      # remove older version if it is still there
+      Remove-Item "$Path\$Product.exe" -Force -ErrorAction Ignore
+      Add-Type -Assembly "System.IO.Compression.FileSystem"
+      [IO.Compression.ZipFile]::ExtractToDirectory($downloadlocation,$Path)
+      Remove-Item $downloadlocation -Force
+
+      success " * $Product was downloaded successfully! You can find it in $Path\$Product.exe"
+
+      If ($UpdateTask.ToLower() -eq 'enable') {
+        # Creating a scheduling task to automatically update the Mondoo client
+        $taskname = $Product + "Updater"
+        $taskpath = $Product
+        If(Get-ScheduledTask -TaskName $taskname -EA 0)
+        {
+            Unregister-ScheduledTask -TaskName $taskname -Confirm:$false
+        }
+        CreateAndRegisterMondooUpdaterTask $taskname $taskpath
+      }
+    } ElseIf ($filetype -eq 'msi') {
+      info ' * Installing msi package...'
+      $file = Get-Item $downloadlocation
+      $packageName = $Product
+      $timeStamp = Get-Date -Format yyyyMMddTHHmmss
+      $logFile = '{0}\{1}-{2}.MsiInstall.log' -f $env:TEMP, $packageName,$timeStamp
+      $argsList = @(
+          "/i"
+          ('"{0}"' -f $file.fullname)
+          "/qn"
+          "/norestart"
+          "/L*v"
+          $logFile
+      )
+
+      info (' * Run installer {0} and log into {1}' -f $downloadlocation, $logFile)
+      $process = Start-Process "msiexec.exe" -Wait -NoNewWindow -PassThru -ArgumentList $argsList
+      # https://docs.microsoft.com/en-us/windows/win32/msi/error-codes
+
+      If (![string]::IsNullOrEmpty($RegistrationToken)) {
+        info " * Register $Product Client"
+        # Set Proxy if enabled
+        If (![string]::IsNullOrEmpty($Proxy)) {
+          $env:https_proxy = $Proxy;
+        }
+        $program = "$Path\$Product.exe"
+        & $program "register", "-t", "$RegistrationToken", "--config", "C:\ProgramData\Mondoo\mondoo.yml"
+      }
+
+      If (@(0,3010) -contains $process.ExitCode) {
+        success " * $Product was installed successfully!"
+      } Else {
+        fail (" * $Product installation failed with exit code: {0}" -f $process.ExitCode)
+      }
+
+      # Check if Service parameter is set and Parameter Product is set to mondoo
+      If ($Service.ToLower() -eq 'enable' -and $Product.ToLower() -eq 'mondoo') {
+        # start Mondoo service
+        enable_service
+      }
+
+      If ($UpdateTask.ToLower() -eq 'enable') {
+        # Creating a scheduling task to automatically update the Mondoo client
+        $taskname = $Product + "Updater"
+        $taskpath = $Product
+        If (Get-ScheduledTask -TaskName $taskname -EA 0)
+        {
+            Unregister-ScheduledTask -TaskName $taskname -Confirm:$false
+        }
+        CreateAndRegisterMondooUpdaterTask $taskname $taskpath
+      }
+
+      Remove-Item $downloadlocation -Force
+
+    } Else {
+      fail "${filetype} is not supported for download"
+    }
+
+    # Display final message
+    info "
+    Thank you for installing $Product!"
+
+  } Else {
+    # Display final message
+    info "
+    Latest $Product version alread installed!"
+  }
+  info "
+    If you have any questions, please come join us in our Mondoo Community on GitHub Discussions:
+
+      * https://github.com/orgs/mondoohq/discussions
+    "
+  # reset erroractionpreference
+  $erroractionpreference = $previous_erroractionpreference
+  }
+}
+
+# SIG # Begin signature block
+# MIIfvAYJKoZIhvcNAQcCoIIfrTCCH6kCAQExDzANBglghkgBZQMEAgEFADB5Bgor
+# BgEEAYI3AgEEoGswaTA0BgorBgEEAYI3AgEeMCYCAwEAAAQQH8w7YFlLCE63JNLG
+# KX7zUQIBAAIBAAIBAAIBAAIBADAxMA0GCWCGSAFlAwQCAQUABCC8cIzMNzZGqqB/
+# yOn0wl5+fjXvoFAC2hOE8lZ4CH3br6CCGmAwggNZMIIC36ADAgECAhAPuKdAuRWN
+# A1FDvFnZ8EApMAoGCCqGSM49BAMDMGExCzAJBgNVBAYTAlVTMRUwEwYDVQQKEwxE
+# aWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5jb20xIDAeBgNVBAMT
+# F0RpZ2lDZXJ0IEdsb2JhbCBSb290IEczMB4XDTIxMDQyOTAwMDAwMFoXDTM2MDQy
+# ODIzNTk1OVowZDELMAkGA1UEBhMCVVMxFzAVBgNVBAoTDkRpZ2lDZXJ0LCBJbmMu
+# MTwwOgYDVQQDEzNEaWdpQ2VydCBHbG9iYWwgRzMgQ29kZSBTaWduaW5nIEVDQyBT
+# SEEzODQgMjAyMSBDQTEwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAS7tKwnpUgNolNf
+# jy6BPi9TdrgIlKKaqoqLmLWx8PwqFbu5s6UiL/1qwL3iVWhga5c0wWZTcSP8GtXK
+# IA8CQKKjSlpGo5FTK5XyA+mrptOHdi/nZJ+eNVH8w2M1eHbk+HejggFXMIIBUzAS
+# BgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBSbX7A2up0GrhknvcCgIsCLizh3
+# 7TAfBgNVHSMEGDAWgBSz20ik+aHF2K42QcwRY2liKbxLxjAOBgNVHQ8BAf8EBAMC
+# AYYwEwYDVR0lBAwwCgYIKwYBBQUHAwMwdgYIKwYBBQUHAQEEajBoMCQGCCsGAQUF
+# BzABhhhodHRwOi8vb2NzcC5kaWdpY2VydC5jb20wQAYIKwYBBQUHMAKGNGh0dHA6
+# Ly9jYWNlcnRzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydEdsb2JhbFJvb3RHMy5jcnQw
+# QgYDVR0fBDswOTA3oDWgM4YxaHR0cDovL2NybDMuZGlnaWNlcnQuY29tL0RpZ2lD
+# ZXJ0R2xvYmFsUm9vdEczLmNybDAcBgNVHSAEFTATMAcGBWeBDAEDMAgGBmeBDAEE
+# ATAKBggqhkjOPQQDAwNoADBlAjB4vUmVZXEB0EZXaGUOaKncNgjB7v3UjttAZT8N
+# /5Ovwq5jhqN+y7SRWnjsBwNnB3wCMQDnnx/xB1usNMY4vLWlUM7m6jh+PnmQ5KRb
+# qwIN6Af8VqZait2zULLd8vpmdJ7QFmMwggP4MIIDfqADAgECAhAMQh2DVCNS9gAH
+# AUDbyB/QMAoGCCqGSM49BAMDMGQxCzAJBgNVBAYTAlVTMRcwFQYDVQQKEw5EaWdp
+# Q2VydCwgSW5jLjE8MDoGA1UEAxMzRGlnaUNlcnQgR2xvYmFsIEczIENvZGUgU2ln
+# bmluZyBFQ0MgU0hBMzg0IDIwMjEgQ0ExMB4XDTIyMDcyNjAwMDAwMFoXDTIzMDgy
+# MzIzNTk1OVowYTELMAkGA1UEBhMCVVMxFzAVBgNVBAgTDk5vcnRoIENhcm9saW5h
+# MQ0wCwYDVQQHEwRDYXJ5MRQwEgYDVQQKEwtNb25kb28sIEluYzEUMBIGA1UEAxML
+# TW9uZG9vLCBJbmMwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAARUDKJuSitW5Rlrgatr
+# LGPgCr66+QWf9M9k+XRq3cvUvZIfU4O8WRoGfx85BDNFg53VhEyTXf/Ue9TJOm3c
+# MxPrVdzIrcfEKWUR2yJ9MGHHu7kUKtenxj68jeb+4f6yQJSjggH2MIIB8jAfBgNV
+# HSMEGDAWgBSbX7A2up0GrhknvcCgIsCLizh37TAdBgNVHQ4EFgQUzssLU2l+Zcug
+# 4YeJgjphzhUKG1gwDgYDVR0PAQH/BAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMD
+# MIGrBgNVHR8EgaMwgaAwTqBMoEqGSGh0dHA6Ly9jcmwzLmRpZ2ljZXJ0LmNvbS9E
+# aWdpQ2VydEdsb2JhbEczQ29kZVNpZ25pbmdFQ0NTSEEzODQyMDIxQ0ExLmNybDBO
+# oEygSoZIaHR0cDovL2NybDQuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0R2xvYmFsRzND
+# b2RlU2lnbmluZ0VDQ1NIQTM4NDIwMjFDQTEuY3JsMD4GA1UdIAQ3MDUwMwYGZ4EM
+# AQQBMCkwJwYIKwYBBQUHAgEWG2h0dHA6Ly93d3cuZGlnaWNlcnQuY29tL0NQUzCB
+# jgYIKwYBBQUHAQEEgYEwfzAkBggrBgEFBQcwAYYYaHR0cDovL29jc3AuZGlnaWNl
+# cnQuY29tMFcGCCsGAQUFBzAChktodHRwOi8vY2FjZXJ0cy5kaWdpY2VydC5jb20v
+# RGlnaUNlcnRHbG9iYWxHM0NvZGVTaWduaW5nRUNDU0hBMzg0MjAyMUNBMS5jcnQw
+# DAYDVR0TAQH/BAIwADAKBggqhkjOPQQDAwNoADBlAjEAv9kLshibq22ggP6mJrc5
+# r2Tr35w1xGELT/N4FteiR+kcXnHg9xM6XiwVVbr+Rg1eAjBAb1FUqzS/PEWYyFcW
+# 1LYHRuRNofwObaW/1ug35EkXC23yn6bh9z4ZUkU3Sv+Rbj0wggWNMIIEdaADAgEC
+# AhAOmxiO+dAt5+/bUOIIQBhaMA0GCSqGSIb3DQEBDAUAMGUxCzAJBgNVBAYTAlVT
+# MRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5j
+# b20xJDAiBgNVBAMTG0RpZ2lDZXJ0IEFzc3VyZWQgSUQgUm9vdCBDQTAeFw0yMjA4
+# MDEwMDAwMDBaFw0zMTExMDkyMzU5NTlaMGIxCzAJBgNVBAYTAlVTMRUwEwYDVQQK
+# EwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5jb20xITAfBgNV
+# BAMTGERpZ2lDZXJ0IFRydXN0ZWQgUm9vdCBHNDCCAiIwDQYJKoZIhvcNAQEBBQAD
+# ggIPADCCAgoCggIBAL/mkHNo3rvkXUo8MCIwaTPswqclLskhPfKK2FnC4SmnPVir
+# dprNrnsbhA3EMB/zG6Q4FutWxpdtHauyefLKEdLkX9YFPFIPUh/GnhWlfr6fqVcW
+# WVVyr2iTcMKyunWZanMylNEQRBAu34LzB4TmdDttceItDBvuINXJIB1jKS3O7F5O
+# yJP4IWGbNOsFxl7sWxq868nPzaw0QF+xembud8hIqGZXV59UWI4MK7dPpzDZVu7K
+# e13jrclPXuU15zHL2pNe3I6PgNq2kZhAkHnDeMe2scS1ahg4AxCN2NQ3pC4FfYj1
+# gj4QkXCrVYJBMtfbBHMqbpEBfCFM1LyuGwN1XXhm2ToxRJozQL8I11pJpMLmqaBn
+# 3aQnvKFPObURWBf3JFxGj2T3wWmIdph2PVldQnaHiZdpekjw4KISG2aadMreSx7n
+# DmOu5tTvkpI6nj3cAORFJYm2mkQZK37AlLTSYW3rM9nF30sEAMx9HJXDj/chsrIR
+# t7t/8tWMcCxBYKqxYxhElRp2Yn72gLD76GSmM9GJB+G9t+ZDpBi4pncB4Q+UDCEd
+# slQpJYls5Q5SUUd0viastkF13nqsX40/ybzTQRESW+UQUOsxxcpyFiIJ33xMdT9j
+# 7CFfxCBRa2+xq4aLT8LWRV+dIPyhHsXAj6KxfgommfXkaS+YHS312amyHeUbAgMB
+# AAGjggE6MIIBNjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTs1+OC0nFdZEzf
+# Lmc/57qYrhwPTzAfBgNVHSMEGDAWgBRF66Kv9JLLgjEtUYunpyGd823IDzAOBgNV
+# HQ8BAf8EBAMCAYYweQYIKwYBBQUHAQEEbTBrMCQGCCsGAQUFBzABhhhodHRwOi8v
+# b2NzcC5kaWdpY2VydC5jb20wQwYIKwYBBQUHMAKGN2h0dHA6Ly9jYWNlcnRzLmRp
+# Z2ljZXJ0LmNvbS9EaWdpQ2VydEFzc3VyZWRJRFJvb3RDQS5jcnQwRQYDVR0fBD4w
+# PDA6oDigNoY0aHR0cDovL2NybDMuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0QXNzdXJl
+# ZElEUm9vdENBLmNybDARBgNVHSAECjAIMAYGBFUdIAAwDQYJKoZIhvcNAQEMBQAD
+# ggEBAHCgv0NcVec4X6CjdBs9thbX979XB72arKGHLOyFXqkauyL4hxppVCLtpIh3
+# bb0aFPQTSnovLbc47/T/gLn4offyct4kvFIDyE7QKt76LVbP+fT3rDB6mouyXtTP
+# 0UNEm0Mh65ZyoUi0mcudT6cGAxN3J0TU53/oWajwvy8LpunyNDzs9wPHh6jSTEAZ
+# NUZqaVSwuKFWjuyk1T3osdz9HNj0d1pcVIxv76FQPfx2CWiEn2/K2yCNNWAcAgPL
+# ILCsWKAOQGPFmCLBsln1VWvPJ6tsds5vIy30fnFqI2si/xK4VC0nftg62fC2h5b9
+# W9FcrBjDTZ9ztwGpn1eqXijiuZQwggauMIIElqADAgECAhAHNje3JFR82Ees/Shm
+# Kl5bMA0GCSqGSIb3DQEBCwUAMGIxCzAJBgNVBAYTAlVTMRUwEwYDVQQKEwxEaWdp
+# Q2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5jb20xITAfBgNVBAMTGERp
+# Z2lDZXJ0IFRydXN0ZWQgUm9vdCBHNDAeFw0yMjAzMjMwMDAwMDBaFw0zNzAzMjIy
+# MzU5NTlaMGMxCzAJBgNVBAYTAlVTMRcwFQYDVQQKEw5EaWdpQ2VydCwgSW5jLjE7
+# MDkGA1UEAxMyRGlnaUNlcnQgVHJ1c3RlZCBHNCBSU0E0MDk2IFNIQTI1NiBUaW1l
+# U3RhbXBpbmcgQ0EwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDGhjUG
+# SbPBPXJJUVXHJQPE8pE3qZdRodbSg9GeTKJtoLDMg/la9hGhRBVCX6SI82j6ffOc
+# iQt/nR+eDzMfUBMLJnOWbfhXqAJ9/UO0hNoR8XOxs+4rgISKIhjf69o9xBd/qxkr
+# PkLcZ47qUT3w1lbU5ygt69OxtXXnHwZljZQp09nsad/ZkIdGAHvbREGJ3HxqV3rw
+# N3mfXazL6IRktFLydkf3YYMZ3V+0VAshaG43IbtArF+y3kp9zvU5EmfvDqVjbOSm
+# xR3NNg1c1eYbqMFkdECnwHLFuk4fsbVYTXn+149zk6wsOeKlSNbwsDETqVcplicu
+# 9Yemj052FVUmcJgmf6AaRyBD40NjgHt1biclkJg6OBGz9vae5jtb7IHeIhTZgirH
+# kr+g3uM+onP65x9abJTyUpURK1h0QCirc0PO30qhHGs4xSnzyqqWc0Jon7ZGs506
+# o9UD4L/wojzKQtwYSH8UNM/STKvvmz3+DrhkKvp1KCRB7UK/BZxmSVJQ9FHzNklN
+# iyDSLFc1eSuo80VgvCONWPfcYd6T/jnA+bIwpUzX6ZhKWD7TA4j+s4/TXkt2ElGT
+# yYwMO1uKIqjBJgj5FBASA31fI7tk42PgpuE+9sJ0sj8eCXbsq11GdeJgo1gJASgA
+# DoRU7s7pXcheMBK9Rp6103a50g5rmQzSM7TNsQIDAQABo4IBXTCCAVkwEgYDVR0T
+# AQH/BAgwBgEB/wIBADAdBgNVHQ4EFgQUuhbZbU2FL3MpdpovdYxqII+eyG8wHwYD
+# VR0jBBgwFoAU7NfjgtJxXWRM3y5nP+e6mK4cD08wDgYDVR0PAQH/BAQDAgGGMBMG
+# A1UdJQQMMAoGCCsGAQUFBwMIMHcGCCsGAQUFBwEBBGswaTAkBggrBgEFBQcwAYYY
+# aHR0cDovL29jc3AuZGlnaWNlcnQuY29tMEEGCCsGAQUFBzAChjVodHRwOi8vY2Fj
+# ZXJ0cy5kaWdpY2VydC5jb20vRGlnaUNlcnRUcnVzdGVkUm9vdEc0LmNydDBDBgNV
+# HR8EPDA6MDigNqA0hjJodHRwOi8vY3JsMy5kaWdpY2VydC5jb20vRGlnaUNlcnRU
+# cnVzdGVkUm9vdEc0LmNybDAgBgNVHSAEGTAXMAgGBmeBDAEEAjALBglghkgBhv1s
+# BwEwDQYJKoZIhvcNAQELBQADggIBAH1ZjsCTtm+YqUQiAX5m1tghQuGwGC4QTRPP
+# MFPOvxj7x1Bd4ksp+3CKDaopafxpwc8dB+k+YMjYC+VcW9dth/qEICU0MWfNthKW
+# b8RQTGIdDAiCqBa9qVbPFXONASIlzpVpP0d3+3J0FNf/q0+KLHqrhc1DX+1gtqpP
+# kWaeLJ7giqzl/Yy8ZCaHbJK9nXzQcAp876i8dU+6WvepELJd6f8oVInw1YpxdmXa
+# zPByoyP6wCeCRK6ZJxurJB4mwbfeKuv2nrF5mYGjVoarCkXJ38SNoOeY+/umnXKv
+# xMfBwWpx2cYTgAnEtp/Nh4cku0+jSbl3ZpHxcpzpSwJSpzd+k1OsOx0ISQ+UzTl6
+# 3f8lY5knLD0/a6fxZsNBzU+2QJshIUDQtxMkzdwdeDrknq3lNHGS1yZr5Dhzq6YB
+# T70/O3itTK37xJV77QpfMzmHQXh6OOmc4d0j/R0o08f56PGYX/sr2H7yRp11LB4n
+# LCbbbxV7HhmLNriT1ObyF5lZynDwN7+YAN8gFk8n+2BnFqFmut1VwDophrCYoCvt
+# lUG3OtUVmDG0YgkPCr2B2RP+v6TR81fZvAT6gt4y3wSJ8ADNXcL50CN/AAvkdgIm
+# 2fBldkKmKYcJRyvmfxqkhQ/8mJb2VVQrH4D6wPIOK+XW+6kvRBVK5xMOHds3OBqh
+# K/bt1nz8MIIGwDCCBKigAwIBAgIQDE1pckuU+jwqSj0pB4A9WjANBgkqhkiG9w0B
+# AQsFADBjMQswCQYDVQQGEwJVUzEXMBUGA1UEChMORGlnaUNlcnQsIEluYy4xOzA5
+# BgNVBAMTMkRpZ2lDZXJ0IFRydXN0ZWQgRzQgUlNBNDA5NiBTSEEyNTYgVGltZVN0
+# YW1waW5nIENBMB4XDTIyMDkyMTAwMDAwMFoXDTMzMTEyMTIzNTk1OVowRjELMAkG
+# A1UEBhMCVVMxETAPBgNVBAoTCERpZ2lDZXJ0MSQwIgYDVQQDExtEaWdpQ2VydCBU
+# aW1lc3RhbXAgMjAyMiAtIDIwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoIC
+# AQDP7KUmOsap8mu7jcENmtuh6BSFdDMaJqzQHFUeHjZtvJJVDGH0nQl3PRWWCC9r
+# ZKT9BoMW15GSOBwxApb7crGXOlWvM+xhiummKNuQY1y9iVPgOi2Mh0KuJqTku3h4
+# uXoW4VbGwLpkU7sqFudQSLuIaQyIxvG+4C99O7HKU41Agx7ny3JJKB5MgB6FVueF
+# 7fJhvKo6B332q27lZt3iXPUv7Y3UTZWEaOOAy2p50dIQkUYp6z4m8rSMzUy5Zsi7
+# qlA4DeWMlF0ZWr/1e0BubxaompyVR4aFeT4MXmaMGgokvpyq0py2909ueMQoP6Mc
+# D1AGN7oI2TWmtR7aeFgdOej4TJEQln5N4d3CraV++C0bH+wrRhijGfY59/XBT3Eu
+# iQMRoku7mL/6T+R7Nu8GRORV/zbq5Xwx5/PCUsTmFntafqUlc9vAapkhLWPlWfVN
+# L5AfJ7fSqxTlOGaHUQhr+1NDOdBk+lbP4PQK5hRtZHi7mP2Uw3Mh8y/CLiDXgazT
+# 8QfU4b3ZXUtuMZQpi+ZBpGWUwFjl5S4pkKa3YWT62SBsGFFguqaBDwklU/G/O+mr
+# Bw5qBzliGcnWhX8T2Y15z2LF7OF7ucxnEweawXjtxojIsG4yeccLWYONxu71LHx7
+# jstkifGxxLjnU15fVdJ9GSlZA076XepFcxyEftfO4tQ6dwIDAQABo4IBizCCAYcw
+# DgYDVR0PAQH/BAQDAgeAMAwGA1UdEwEB/wQCMAAwFgYDVR0lAQH/BAwwCgYIKwYB
+# BQUHAwgwIAYDVR0gBBkwFzAIBgZngQwBBAIwCwYJYIZIAYb9bAcBMB8GA1UdIwQY
+# MBaAFLoW2W1NhS9zKXaaL3WMaiCPnshvMB0GA1UdDgQWBBRiit7QYfyPMRTtlwvN
+# PSqUFN9SnDBaBgNVHR8EUzBRME+gTaBLhklodHRwOi8vY3JsMy5kaWdpY2VydC5j
+# b20vRGlnaUNlcnRUcnVzdGVkRzRSU0E0MDk2U0hBMjU2VGltZVN0YW1waW5nQ0Eu
+# Y3JsMIGQBggrBgEFBQcBAQSBgzCBgDAkBggrBgEFBQcwAYYYaHR0cDovL29jc3Au
+# ZGlnaWNlcnQuY29tMFgGCCsGAQUFBzAChkxodHRwOi8vY2FjZXJ0cy5kaWdpY2Vy
+# dC5jb20vRGlnaUNlcnRUcnVzdGVkRzRSU0E0MDk2U0hBMjU2VGltZVN0YW1waW5n
+# Q0EuY3J0MA0GCSqGSIb3DQEBCwUAA4ICAQBVqioa80bzeFc3MPx140/WhSPx/PmV
+# OZsl5vdyipjDd9Rk/BX7NsJJUSx4iGNVCUY5APxp1MqbKfujP8DJAJsTHbCYidx4
+# 8s18hc1Tna9i4mFmoxQqRYdKmEIrUPwbtZ4IMAn65C3XCYl5+QnmiM59G7hqopvB
+# U2AJ6KO4ndetHxy47JhB8PYOgPvk/9+dEKfrALpfSo8aOlK06r8JSRU1NlmaD1TS
+# sht/fl4JrXZUinRtytIFZyt26/+YsiaVOBmIRBTlClmia+ciPkQh0j8cwJvtfEiy
+# 2JIMkU88ZpSvXQJT657inuTTH4YBZJwAwuladHUNPeF5iL8cAZfJGSOA1zZaX5YW
+# sWMMxkZAO85dNdRZPkOaGK7DycvD+5sTX2q1x+DzBcNZ3ydiK95ByVO5/zQQZ/Ym
+# Mph7/lxClIGUgp2sCovGSxVK05iQRWAzgOAj3vgDpPZFR+XOuANCR+hBNnF3rf2i
+# 6Jd0Ti7aHh2MWsgemtXC8MYiqE+bvdgcmlHEL5r2X6cnl7qWLoVXwGDneFZ/au/C
+# lZpLEQLIgpzJGgV8unG1TnqZbPTontRamMifv427GFxD9dAq6OJi7ngE273R+1sK
+# qHB+8JeEeOMIA11HLGOoJTiXAdI/Otrl5fbmm9x+LMz/F0xNAKLY1gEOuIvu5uBy
+# VYksJxlh9ncBjDGCBLIwggSuAgEBMHgwZDELMAkGA1UEBhMCVVMxFzAVBgNVBAoT
+# DkRpZ2lDZXJ0LCBJbmMuMTwwOgYDVQQDEzNEaWdpQ2VydCBHbG9iYWwgRzMgQ29k
+# ZSBTaWduaW5nIEVDQyBTSEEzODQgMjAyMSBDQTECEAxCHYNUI1L2AAcBQNvIH9Aw
+# DQYJYIZIAWUDBAIBBQCggYQwGAYKKwYBBAGCNwIBDDEKMAigAoAAoQKAADAZBgkq
+# hkiG9w0BCQMxDAYKKwYBBAGCNwIBBDAcBgorBgEEAYI3AgELMQ4wDAYKKwYBBAGC
+# NwIBFTAvBgkqhkiG9w0BCQQxIgQgYfA/2adZ8EhzpBVlzVMmMMAWC1Qe91APaOOB
+# Fhj+2PIwCwYHKoZIzj0CAQUABGgwZgIxAJypYzih3DQlG4pGpgx+1n+IzjYamxpA
+# 9sgvwz7HvkpxwpQ6FEdfbhwOmIKK9+ToSwIxAJRGTfY8P3auIEp6tPfUmG9Gj+CZ
+# ZWwkFIHOFZmuVibrkAjrT2NlG9twmr50uQbknKGCAyAwggMcBgkqhkiG9w0BCQYx
+# ggMNMIIDCQIBATB3MGMxCzAJBgNVBAYTAlVTMRcwFQYDVQQKEw5EaWdpQ2VydCwg
+# SW5jLjE7MDkGA1UEAxMyRGlnaUNlcnQgVHJ1c3RlZCBHNCBSU0E0MDk2IFNIQTI1
+# NiBUaW1lU3RhbXBpbmcgQ0ECEAxNaXJLlPo8Kko9KQeAPVowDQYJYIZIAWUDBAIB
+# BQCgaTAYBgkqhkiG9w0BCQMxCwYJKoZIhvcNAQcBMBwGCSqGSIb3DQEJBTEPFw0y
+# MjEyMzAxMTE4NTRaMC8GCSqGSIb3DQEJBDEiBCDeeAVQpKRqb6lPFf9kvORl2msy
+# gyy8epJfRji3JEGaATANBgkqhkiG9w0BAQEFAASCAgCtiJyR/clM2ttcgPHIhzR3
+# Ywnp+V8weZv25uSR9BymSnPp4zaWrKipPcI7XQYonwR1HGxDxzElXhgC24v7YTKB
+# nyklzmwkfSFOpESwMURX8o95Y8I0GjZmv1PtZI/pKGbUAeuUtCy4Ug2PlDj1O6FQ
+# gjLcp3EQYzBC2hUWtVHpz58/L0mLcZ7gGDpCqF/Uo4QproIclgR3FthQ/h67SQ5X
+# kvAq8u+P5kehgiKcaypFz7XCJ0JDzP677SBOtm4sLXO1WRH50DJfTp30lsjC7KQv
+# NGBPvU/npcUnbWEKM0Dt7e5oYl+D2Nzy3aYtGR/V7RGqOhqZw3VaH0lwbTeWI3JJ
+# SOicZKnBKa5reWZLlqyNW0vtKkb75aQnafUp/jbHewMcvvI/CRn5IAau/hBeCfQm
+# 6epfk9fd7A4s0xs0OysKpmOfRwmbX0gNdO8q+8/sXJ6S0pJL5iEe5vvGPkdAAp7O
+# AkOK2CfKACjkxyU9EYqzXlW1/KHpVG+mjN9As7vpHN6IarOiY7No5c/SQ6mEyXLs
+# QJpblpMyU/H8AiAtRZjQEikGFg22DcOurGFS3rbe1zetRJxFMqSzmE3r2zTW+brF
+# D1lV4Sq6HZ1X6yPBluJmWU6rPg7Jb+Jy77MNqdSGd3FKSY3A27Euz506JpkNSmay
+# T82wovuoX3+kX54Pu+gGjg==
+# SIG # End signature block


### PR DESCRIPTION
Turns the current install.ps1 into a module to make the installation much easier under Windows. The module is published on Powershell Gallery https://www.powershellgallery.com/packages/Mondoo.Installer.

Now the installation is as easy as:

```
Install-Module -Name Mondoo.Installer
Install-Mondoo
```

I used the following two resources to develop the module:

- https://learn.microsoft.com/en-us/powershell/scripting/developer/module/how-to-write-a-powershell-script-module?view=powershell-7.3
- https://learn.microsoft.com/en-us/powershell/scripting/developer/module/how-to-write-a-powershell-module-manifest?view=powershell-7.3

For local development, make sure you have the latest Powershell 7 installed. I experienced issues when trying to publish modules on older Powershell versions. Publishing also does not work from Linux or Mac, only Windows is supported.
