### PR TITLE
🧹 Update repository links

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ Example   | Phase | Description |
 
 **Mondoo Scripts**
 
-- [install.sh](./install.sh) - Mondoo Agent Bash Installer for Servers
-- [download.sh](./download.sh) - Mondoo Agent Bash Downloader for Workstation
+- [install.sh](./install.sh) - Mondoo Client Bash Installer for Servers
+- [download.sh](./download.sh) - Mondoo Client Bash Downloader for Workstation
 - [Dockerfile](./Dockerfile) - Build script for official Mondoo container
 
 **Docker Containers**
 
-- https://hub.docker.com/r/mondoolabs/mondoo
+- https://hub.docker.com/r/mondoo/client
 
 **Installation Packages**
 

--- a/dockerhub/mondoo/client.md
+++ b/dockerhub/mondoo/client.md
@@ -7,25 +7,27 @@
 * Release Notes: https://mondoo.com/releases/
 * Documentation: [mondoo.com/docs](https://mondoo.com/docs/)
 * Where to get help: [Mondoo Community GitHub Discussions](https://github.com/orgs/mondoohq/discussions)
-* Dockerfile Source: https://github.com/mondoohq/client/blob/master/Dockerfile
-* Where to file issues: https://github.com/mondoohq/client/issues
+* Dockerfile Source: https://github.com/mondoohq/installer/blob/main/Dockerfile
+* Where to file issues: https://github.com/mondoohq/installer/issues
 * Mondoo Client Binary Downloads (Non-Container):  https://releases.mondoo.com/mondoo/
 * Supported Architectures: `amd64`, `arm64`, `i386`, `arm32v6`, `arm32v7`
 
 ## Supported tags
+
 - `latest` - always pinned to the latest release of Mondoo Client
 - `7` - always pinned to the latest release for a given major version
-- `7.2.0` - always pinned to a specific Mondoo Client release
+- `7.12.0` - always pinned to a specific Mondoo Client release
 
 ## UBI containers
+
 We offer a Mondoo Client container built on top of [Universal Base Image (UBI)](https://hub.docker.com/r/redhat/ubi8) by Red Hat. Note that the containers built with this base image support only the `amd64` and `arm64` architectures.
 
 Supported tags are:
 - `latest-ubi`
 - `7-ubi`
-- `7.2.0-ubi`
+- `7.12.0-ubi`
 
-The `Dockerfile` for these images can be found [here](https://github.com/mondoohq/client/blob/master/Dockerfile-ubi).
+The `Dockerfile` for these images can be found [here](https://github.com/mondoohq/installer/blob/main/Dockerfile-ubi).
 
 ## Rootless containers
 The default Mondoo Client container runs our binary as the `root` user. This makes it easy to run a filesystem scan on the host or to use our Cloud Run capabilities. If neither of these use-cases are applicable, we recommend using the rootless containers that we offer. Instead of running under the `root` user, the Mondoo Client will run using the `mondoo` user.
@@ -35,8 +37,8 @@ Supported tags are:
 - `latest-ubi-rootless`
 - `7-rootless`
 - `7-ubi-rootless`
-- `7.2.0-rootless`
-- `7.2.0-ubi-rootless`
+- `7.12.0-rootless`
+- `7.12.0-ubi-rootless`
 
 # What is Mondoo
 

--- a/dockerhub/mondoolabs/mondoo.md
+++ b/dockerhub/mondoolabs/mondoo.md
@@ -9,15 +9,16 @@
 * Release Notes: https://mondoo.com/releases/
 * Documentation: [mondoo.com/docs](https://mondoo.com/docs/)
 * Where to get help: [Mondoo Community GitHub Discussions](https://github.com/orgs/mondoohq/discussions)
-* Dockerfile Source: https://github.com/mondoohq/client/blob/master/Dockerfile
-* Where to file issues: https://github.com/mondoohq/client/issues
+* Dockerfile Source: https://github.com/mondoohq/installer/blob/main/Dockerfile
+* Where to file issues: https://github.com/mondoohq/installer/issues
 * Mondoo Client Binary Downloads (Non-Container):  https://releases.mondoo.com/mondoo/
 * Supported Architectures: `amd64`, `arm64`, `i386`, `arm32v6`, `arm32v7`
 
 ## Supported tags
+
 - `latest` - always pinned to the latest release of Mondoo Client
 - `7` - always pinned to the latest release for a given major version
-- `7.2.0` - always pinned to a specific Mondoo Client release
+- `7.12.0` - always pinned to a specific Mondoo Client release
 
 # What is Mondoo
 

--- a/download.sh
+++ b/download.sh
@@ -51,7 +51,7 @@ experiencing any issues, please do not hesitate to reach out:
 
   * Mondoo Community GitHub Discussions https://github.com/orgs/mondoohq/discussions
 
-This script source is available at: https://github.com/mondoohq/client
+This script source is available at: https://github.com/mondoohq/installer
 "
 
 base_url="${MONDOO_MIRROR:-https://install.mondoo.com/package}"
@@ -125,7 +125,7 @@ fi
 # Display final message
 purple_bold "\nThank you for downloading Mondoo!"
 echo -e "
-You can register the agent via:
+You can register the client via:
 
 MONDOO_REGISTRATION_TOKEN=\"ey..iU\"
 mondoo register --token \$MONDOO_REGISTRATION_TOKEN
@@ -135,5 +135,5 @@ Further information is available at https://mondoo.com/docs
 If you have any questions, please come join us in our Mondoo Community:
 
 * Mondoo Community GitHub Discussions https://github.com/orgs/mondoohq/discussions
-* Github: https://github.com/mondoohq/client
+* GitHub: https://github.com/mondoohq/
 "

--- a/install.sh
+++ b/install.sh
@@ -57,7 +57,7 @@ on_error() {
   echo
   echo "* Mondoo Community GitHub Discussions https://github.com/orgs/mondoohq/discussions"
   echo
-  echo "* GitHub: https://github.com/mondoohq/client"
+  echo "* GitHub: https://github.com/mondoohq/installer"
   echo
   exit 1
 }
@@ -84,7 +84,7 @@ If you experience any issues, please reach us at:
 This installer is licensed under the Apache License, Version 2.0
 
   * GitHub:
-  https://github.com/mondoohq/client
+  https://github.com/mondoohq/installer
 
 "
 


### PR DESCRIPTION
- The client repo is now the installer repo
- Link to our org which has our pinned repos instead of the installer repo
- Github -> GitHub
- master branch -> main branch
- Agent -> Client
- Fix the dead Docker Hub link
- Fix some markdown warnings
- Update some versions to be 10 weeks newer

Signed-off-by: Tim Smith <tsmith84@gmail.com>