### PR TITLE
⭐ Check mondoo releases via installer

### DIFF
--- a/.github/workflows/test_with_container_build.yml
+++ b/.github/workflows/test_with_container_build.yml
@@ -1,0 +1,52 @@
+name: Test Mondoo Releases with Container Builds
+
+on:
+  workflow_dispatch:
+
+
+jobs:
+  build_container:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        dockerfile:
+          - "almalinux.arm64.Dockerfile"
+          - "almalinux.Dockerfile"
+          - "amazonlinux2.Dockerfile"
+          - "debian.Dockerfile"
+          - "opensuse_leap.Dockerfile"
+          - "redhat.Dockerfile"
+          - "ubuntu.Dockerfile"
+    name: Install Mondoo inside containers to test new releases
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: arm64,arm
+
+      - name: Set up Docker BuildX
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push root images (alpine)
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: test/install_sh/${{ matrix.dockerfile }}
+          push: false
+          tags: |
+            mondoohq/mondoo-install-test:${{ matrix.dockerfile }}
+
+      - name: Discord notification
+        uses: Ilshidur/action-discord@0.3.2
+        if: failure()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        with:
+          args: ':warning: Mondoo install failed in test container!  (https://github.com/mondoohq/installer/actions/workflows/test_with_container_build.yml)'


### PR DESCRIPTION
This workflow should be called when new releases of Mondoo get pushed to the repos. The tests should show quickly whether we have a problem with the installer.

Signed-off-by: Christian Zunker <christian@mondoo.com>