### PR TITLE
✨ Run install tests after release

### DIFF
--- a/.github/workflows/test_with_container_build.yml
+++ b/.github/workflows/test_with_container_build.yml
@@ -1,6 +1,10 @@
 name: Test Mondoo Releases with Container Builds
 
 on:
+  workflow_run:
+    workflows: ['Update Release Version'] # runs after release
+    types:
+      - completed
   workflow_dispatch:
 
 


### PR DESCRIPTION
At this point in time, the repos are updated with the latest client verison and the installer should fetch it.

Also add tests for i386 platform as we release this.