### PR TITLE
🐛 use cnspec as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,25 +9,7 @@
 FROM docker.io/mondoo/cnspec:${VERSION} AS root
 ARG VERSION
 
-ARG TARGETOS
-ARG TARGETARCH
-ARG TARGETVARIANT
-
-ARG BASEURL="https://releases.mondoo.com/mondoo/${VERSION}"
-ARG PACKAGE="mondoo_${VERSION}_${TARGETOS}_${TARGETARCH}${TARGETVARIANT}.tar.gz"
-
-RUN apk update &&\
-    apk add ca-certificates wget tar &&\
-    wget --quiet --output-document=SHA256SUMS ${BASEURL}/checksums.linux.txt &&\
-    wget --quiet --output-document=${PACKAGE} ${BASEURL}/${PACKAGE} &&\
-    cat SHA256SUMS | grep "${PACKAGE}" | sha256sum -c - &&\
-    tar -xzC /usr/local/bin -f ${PACKAGE} &&\
-    /usr/local/bin/mondoo version &&\
-    rm -f ${PACKAGE} SHA256SUMS &&\
-    apk del wget tar --quiet &&\
-    rm -rf /var/cache/apk/*
- 
-ENTRYPOINT [ "mondoo" ]
+ENTRYPOINT [ "cnquery" ]
 CMD ["help"]
 
 # Rootless version of the container

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # To build rootless images with BuildX:   docker buildx build --build-arg VERSION=5.21.0 --platform 
 #             linux/386,linux/amd64,linux/arm/v7,linux/arm64 --target rootless -t mondoolabs/mondoo:5.21.0 . --push
 
-FROM alpine:3.17 AS root
+FROM docker.io/mondoo/cnspec:${VERSION} AS root
 ARG VERSION
 
 ARG TARGETOS

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 FROM docker.io/mondoo/cnspec:${VERSION} AS root
 ARG VERSION
 
-ENTRYPOINT [ "cnquery" ]
+ENTRYPOINT [ "cnspec" ]
 CMD ["help"]
 
 # Rootless version of the container


### PR DESCRIPTION
now that mondoo binary calls out to cnspec, we need to ensure that cnspec is actually there to call to