### PR TITLE
Add Repobuilder to downstream

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     ## Matrix task, repeats steps for each repo
     strategy:
       matrix:
-        repo: ["mondoohq/homebrew-mondoo", "mondoohq/archlinux-package", "mondoohq/mac-pkg", "mondoohq/chocolatey", "mondoohq/msi-builder"]
+        repo: ["mondoohq/homebrew-mondoo", "mondoohq/archlinux-package", "mondoohq/mac-pkg", "mondoohq/chocolatey", "mondoohq/msi-builder", "mondoohq/repobuilder"]
     steps:
       - uses: actions/checkout@v3
       - name: Repository Dispatch (Workflow Dispatch)


### PR DESCRIPTION
This will trigger generation and deployment of both RPM and Debian repositories.