### PR TITLE
🧹 allow overwrite of the installer type for install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,8 +48,10 @@ MONDOO_BINARY="mondoo" # binary that we search for
 MONDOO_INSTALLER=''
 
 print_usage() {
-  echo "usage: $0 " >&2
-  echo "  [-i] overwrite install type: macOS (pkg, brew)" >&2
+  echo "usage: [-i]" >&2
+  echo "  Options: " >&2
+  echo "    -i <installer>:  Select a specific installer, options are:" >&2
+  echo "                     macOS: brew, pkg " >&2
 }
 
 while getopts 'i:v' flag; do

--- a/install.sh
+++ b/install.sh
@@ -48,12 +48,13 @@ MONDOO_BINARY="mondoo" # binary that we search for
 MONDOO_INSTALLER=''
 
 print_usage() {
-  echo "usage: [-t]" >&2
+  echo "usage: $0 " >&2
+  echo "  [-i] overwrite install type: macOS (pkg, brew)" >&2
 }
 
-while getopts 't:v' flag; do
+while getopts 'i:v' flag; do
   case "${flag}" in
-    t) MONDOO_INSTALLER="${OPTARG}" ;;
+    i) MONDOO_INSTALLER="${OPTARG}" ;;
     *) print_usage
        exit 1 ;;
   esac


### PR DESCRIPTION
This allows users to overwrite the default package detection for macOS.

By default the install script tries to detect the best installer type. For automation, you may want to specify the package type. This can be done with the new `-t` which is support for macOS first. 

It can be tested locally via:

```
bash -c "$(cat install.sh)" -- -i pkg
```