### PR TITLE
🐛 fix install.sh to skip authentication when no registration token was provided

### DIFF
--- a/.github/workflows/test_with_container_build.yml
+++ b/.github/workflows/test_with_container_build.yml
@@ -6,7 +6,11 @@ on:
     types:
       - completed
   workflow_dispatch:
-
+  push:
+    branches:
+      - main
+    paths:
+      - 'install.sh'
 
 jobs:
   build_container:

--- a/install.sh
+++ b/install.sh
@@ -45,6 +45,7 @@ MONDOO_BINARY="cnspec" # binary that we search for
 
 # read bash flags
 MONDOO_INSTALLER=''
+MONDOO_REGISTRATION_TOKEN=''
 
 print_usage() {
   echo "usage: [-i]" >&2
@@ -485,7 +486,13 @@ detect_mondoo_registered() {
 }
 
 configure_token() {
+  if [ -z "${MONDOO_REGISTRATION_TOKEN}" ]; then
+    echo -e "\n* No registration token provided, skipping Mondoo Platform authentication."
+    return
+  fi
+
   detect_mondoo_registered
+
   if [ "$MONDOO_IS_REGISTERED" = true ]; then
     purple_bold "\n* ${MONDOO_PRODUCT_NAME} is already logged-in. Skipping login"
     purple_bold "(you can manually run '${MONDOO_BINARY} login' to re-authenticate)."


### PR DESCRIPTION
This fixes an issue introduced in https://github.com/mondoohq/installer/pull/309/files#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL486-L494