### PR TITLE
🧹 Update the examples for DockerHub to be 8.x

### DIFF
--- a/dockerhub/mondoo/client.md
+++ b/dockerhub/mondoo/client.md
@@ -15,8 +15,8 @@
 ## Supported tags
 
 - `latest` - always pinned to the latest release of mondoo package
-- `7` - always pinned to the latest release for a given major version
-- `7.12.0` - always pinned to a specific mondoo package release
+- `8` - always pinned to the latest release for a given major version
+- `8.20.0` - always pinned to a specific mondoo package release
 
 ## UBI containers
 
@@ -24,8 +24,8 @@ We offer a Mondoo Client container built on top of [Universal Base Image (UBI)](
 
 Supported tags are:
 - `latest-ubi`
-- `7-ubi`
-- `7.12.0-ubi`
+- `8-ubi`
+- `8.20.0-ubi`
 
 The `Dockerfile` for these images can be found [here](https://github.com/mondoohq/installer/blob/main/Dockerfile-ubi).
 

--- a/dockerhub/mondoolabs/mondoo.md
+++ b/dockerhub/mondoolabs/mondoo.md
@@ -16,9 +16,9 @@
 
 ## Supported tags
 
-- `latest` - always pinned to the latest release of Mondoo Client
-- `7` - always pinned to the latest release for a given major version
-- `7.12.0` - always pinned to a specific Mondoo Client release
+- `latest` - always pinned to the latest release of Mondoo
+- `8` - always pinned to the latest release for a given major version
+- `8.20.0` - always pinned to a specific Mondoo release
 
 # What is Mondoo
 


### PR DESCRIPTION
Small little change to have more up to date examples. Also remove a few "client" words.