### PR TITLE
Revert changes for v9

### DIFF
--- a/.github/workflows/pkg_arch-aur.yaml
+++ b/.github/workflows/pkg_arch-aur.yaml
@@ -13,8 +13,8 @@ on:
         required: false
         default: false
         type: boolean
-  release:
-    types: [published]
+  # release:
+  #   types: [published]
 
 jobs:
   setup:

--- a/.github/workflows/pkg_chocolatey.yaml
+++ b/.github/workflows/pkg_chocolatey.yaml
@@ -8,8 +8,8 @@ on:
         required: true
         type: string
         default: "8.0.0"
-  release:
-    types: [published]
+  # release:
+  #   types: [published]
 
 jobs:
   chocotize:

--- a/.github/workflows/pkg_macos.yaml
+++ b/.github/workflows/pkg_macos.yaml
@@ -16,8 +16,8 @@ on:
         required: false
         default: false
         type: boolean
-  release:
-    types: [released]
+  # release:
+  #   types: [released]
 
 jobs:
   pkg:

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -16,8 +16,8 @@ on:
         required: false
         default: false
         type: boolean
-  release:
-    types: [published]
+  # release:
+  #   types: [published]
 
 jobs:
   setup:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
     ## Matrix task, repeats steps for each repo
     strategy:
       matrix:
-        repo: ["mondoohq/chocolatey", "mondoohq/msi-builder", "mondoohq/repobuilder"]
+        repo: ["mondoohq/archlinux-package", "mondoohq/mac-pkg", "mondoohq/chocolatey", "mondoohq/msi-builder", "mondoohq/repobuilder"]
     steps:
       - uses: actions/checkout@v3
       - name: Repository Dispatch (Workflow Dispatch)
@@ -139,4 +139,3 @@ jobs:
           repository: ${{ matrix.repo }}
           event-type: update
           client-payload: '{"version": "${{ github.event.release.tag_name }}"}'
-


### PR DESCRIPTION
Temporarily revert out the changes for v9, this means:

- Unarchiving the downstream repos
- Enabling each downstream into the matrix build for release
- Disabing the release event on each of the new PKG builders