### PR TITLE
v9: Update the path to the license file for choco

### DIFF
--- a/packages/chocolatey/cnquery-generate.sh
+++ b/packages/chocolatey/cnquery-generate.sh
@@ -25,7 +25,7 @@ cat >cnquery.nuspec <<NUSPEC
     <projectUrl>https://github.com/mondoohq/cnquery</projectUrl>
     <iconUrl>https://mondoo.com/mondoo_choco_logo.jpg</iconUrl>
     <copyright>2022 Mondoo, Inc.</copyright>
-    <licenseUrl>https://github.com/mondoohq/cnquery/blob/main/LICENSE.txt</licenseUrl>
+    <licenseUrl>https://github.com/mondoohq/cnquery/blob/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <docsUrl>https://mondoo.com/docs/cnquery/</docsUrl>
     <bugTrackerUrl>https://github.com/mondoohq/cnquery/issues</bugTrackerUrl>

--- a/packages/chocolatey/cnspec-generate.sh
+++ b/packages/chocolatey/cnspec-generate.sh
@@ -30,7 +30,7 @@ cat >cnspec.nuspec <<NUSPEC
     <projectUrl>https://github.com/mondoohq/cnspec</projectUrl>
     <iconUrl>https://mondoo.com/mondoo_choco_logo.jpg</iconUrl>
     <copyright>2023 Mondoo, Inc.</copyright>
-    <licenseUrl>https://github.com/mondoohq/cnspec/blob/main/LICENSE.txt</licenseUrl>
+    <licenseUrl>https://github.com/mondoohq/cnspec/blob/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <docsUrl>https://mondoo.com/docs/cnspec/</docsUrl>
     <bugTrackerUrl>https://github.com/mondoohq/cnspec/issues</bugTrackerUrl>


### PR DESCRIPTION
It's no longer LICENSE.txt so choco validation is failing