### PR TITLE
Update signing for Windows and Mac

### DIFF
--- a/.github/workflows/pkg_macos.yaml
+++ b/.github/workflows/pkg_macos.yaml
@@ -82,7 +82,7 @@ jobs:
           productsign --sign "${{ secrets.APPLE_KEYS_PRODUCTSIGN_ID }}" dist/${{ steps.version.outputs.name }}-macos-universal-${{ steps.version.outputs.version }}.pkg dist/${{ steps.version.outputs.name }}_${{ steps.version.outputs.version }}_darwin_universal.pkg
       ########## Sign Package. ##########
       - name: "Notarize Signed PKG"
-        uses: devbotsxyz/xcode-notarize@v1
+        uses: mondoohq/xcode-notarize@v1
         with:
           product-path: dist/${{ steps.version.outputs.name }}_${{ steps.version.outputs.version }}_darwin_universal.pkg
           appstore-connect-username: ${{ secrets.APPLE_ACCOUNT_USERNAME }}
@@ -90,7 +90,7 @@ jobs:
           primary-bundle-id: 'com.${{ steps.version.outputs.name }}.client'
 
       - name: "Staple Release Build"
-        uses: devbotsxyz/xcode-staple@v1
+        uses: mondoohq/xcode-staple@v1
         with:
           product-path: dist/${{ steps.version.outputs.name }}_${{ steps.version.outputs.version }}_darwin_universal.pkg
       ########## Save Package as Artifact. ##########

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -133,7 +133,7 @@ jobs:
           ./package.ps1 -version $mondooVersion
           # sign msi package
           echo " - Signing MSI..."
-          Set-Location -Path '.\..'
+          Set-Location -Path '.\..\..'
           signtool.exe sign /sha1 ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 .\packages\msi\mondoo.msi
           Copy-Item '.\packages\msi\mondoo.msi' '.\dist\'
 

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -89,6 +89,7 @@ jobs:
         with:
           name: dist
           path: dist
+
       - name: Setup Certificate
         shell: bash
         run: |
@@ -122,19 +123,19 @@ jobs:
         run: |
           $mondooVersion = ${env:VERSION}
           echo "Running build job for version ${mondooVersion}"
-          Copy-Item .\dist\cnquery.exe .\scripts\msi\
-          Copy-Item .\dist\cnspec.exe .\scripts\msi\
-          Copy-Item .\dist\cnquery.exe .\scripts\appx\
-          Copy-Item .\dist\cnspec.exe .\scripts\appx\
+          Copy-Item .\dist\cnquery.exe .\packages\msi\msi\
+          Copy-Item .\dist\cnspec.exe .\packages\msi\msi\
+          Copy-Item .\dist\cnquery.exe .\packages\msi\appx\
+          Copy-Item .\dist\cnspec.exe .\packages\msi\appx\
           # build msi package
           echo " - Packaging MSI..."
-          Set-Location -Path '.\scripts\'
+          Set-Location -Path '.\packages\msi\'
           ./package.ps1 -version $mondooVersion
           # sign msi package
           echo " - Signing MSI..."
           Set-Location -Path '.\..'
-          signtool.exe sign /sha1 ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 .\scripts\mondoo.msi
-          Copy-Item '.\scripts\mondoo.msi' '.\dist\'
+          signtool.exe sign /sha1 ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 .\packages\msi\mondoo.msi
+          Copy-Item '.\packages\msi\mondoo.msi' '.\dist\'
 
       - name: Cleanup dist before upload
         run: |

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -122,11 +122,8 @@ jobs:
         run: |
           $mondooVersion = ${env:VERSION}
           echo "Running build job for version ${mondooVersion}"
-          echo " - Signing executables..."
-          signtool.exe sign /sha1 ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 .\dist\mondoo.exe
           Copy-Item .\dist\cnquery.exe .\scripts\msi\
           Copy-Item .\dist\cnspec.exe .\scripts\msi\
-          Copy-Item .\dist\mondoo.exe .\scripts\appx\
           Copy-Item .\dist\cnquery.exe .\scripts\appx\
           Copy-Item .\dist\cnspec.exe .\scripts\appx\
           # build msi package
@@ -143,7 +140,6 @@ jobs:
         run: |
           Remove-Item -Path .\dist\cnquery.exe -Force
           Remove-Item -Path .\dist\cnspec.exe -Force
-          Remove-Item -Path ${env:SM_CLIENT_CERT_FILE} -Force
 
       - name: Upload Distribution
         uses: actions/upload-artifact@v3

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -89,37 +89,62 @@ jobs:
         with:
           name: dist
           path: dist
-      - name: Fetch Signing Key
+      - name: Setup Certificate
+        shell: bash
         run: |
-          $base64String = "${{ secrets.MSI_SIGNING_CERT }}"
-          $bytes = [System.Convert]::FromBase64String($base64String)
-          Set-Content -Path "signing.cert" -Value $bytes -AsByteStream
-      - name: Build MSI
+          echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
+
+      - name: Set signing variables
+        shell: bash
+        run: |
+          echo "SM_HOST=${{ secrets.SM_HOST }}" >> "$GITHUB_ENV"
+          echo "SM_API_KEY=${{ secrets.SM_API_KEY }}" >> "$GITHUB_ENV"
+          echo "SM_CLIENT_CERT_FILE=D:\\Certificate_pkcs12.p12" >> "$GITHUB_ENV"
+          echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_CLIENT_CERT_PASSWORD }}" >> "$GITHUB_ENV"
+          echo "SM_CODE_SIGNING_CERT_SHA1_HASH=${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}" >> "$GITHUB_ENV"
+          echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH
+          echo "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools" >> $GITHUB_PATH
+          echo "C:\Program Files\DigiCert\DigiCert One Signing Manager Tools" >> $GITHUB_PATH
+
+      - name: Setup SSM KSP on windows latest
+        shell: cmd
+        run: |
+          curl -X GET  https://one.digicert.com/signingmanager/api-ui/v1/releases/smtools-windows-x64.msi/download -H "x-api-key:%SM_API_KEY%" -o smtools-windows-x64.msi
+          msiexec /i smtools-windows-x64.msi /quiet /qn
+          smksp_registrar.exe list
+          smctl.exe keypair ls
+          C:\Windows\System32\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user
+          smksp_cert_sync.exe
+
+      - name: Build and Sign MSI
         env:
           VERSION: ${{ needs.setup.outputs.version }}
-          NAME: ${{ needs.setup.outputs.name }}
-          PASSWORD: ${{ secrets.MSI_SIGNING_PASSWORD }}
         run: |
           $mondooVersion = ${env:VERSION}
-          echo "running build job for mondoo ${mondooVersion}"
-          $certPath = "$pwd\signing.cert"
-          $pass = ${env:PASSWORD}
-          Copy-Item .\dist\cnquery.exe .\packages\msi\msi\
-          Copy-Item .\dist\cnspec.exe .\packages\msi\msi\
-          Copy-Item .\dist\cnquery.exe .\packages\msi\appx\
-          Copy-Item .\dist\cnspec.exe .\packages\msi\appx\
+          echo "Running build job for version ${mondooVersion}"
+          echo " - Signing executables..."
+          signtool.exe sign /sha1 ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 .\dist\mondoo.exe
+          Copy-Item .\dist\cnquery.exe .\scripts\msi\
+          Copy-Item .\dist\cnspec.exe .\scripts\msi\
+          Copy-Item .\dist\mondoo.exe .\scripts\appx\
+          Copy-Item .\dist\cnquery.exe .\scripts\appx\
+          Copy-Item .\dist\cnspec.exe .\scripts\appx\
           # build msi package
-          Set-Location -Path '.\packages\msi\'
+          echo " - Packaging MSI..."
+          Set-Location -Path '.\scripts\'
           ./package.ps1 -version $mondooVersion
           # sign msi package
-          Set-Location -Path '.\..\..'
-          .\packages\msi\sign.ps1 -ProgramName "Mondoo Installer" -Certificate $certPath -Password $pass -Executable .\packages\msi\mondoo.msi
-          Copy-Item '.\packages\msi\mondoo.msi' '.\dist\'
-      - name: Cleanup
+          echo " - Signing MSI..."
+          Set-Location -Path '.\..'
+          signtool.exe sign /sha1 ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 .\scripts\mondoo.msi
+          Copy-Item '.\scripts\mondoo.msi' '.\dist\'
+
+      - name: Cleanup dist before upload
         run: |
           Remove-Item -Path .\dist\cnquery.exe -Force
           Remove-Item -Path .\dist\cnspec.exe -Force
-          Remove-Item -Path .\signing.cert -Force
+          Remove-Item -Path ${env:SM_CLIENT_CERT_FILE} -Force
+
       - name: Upload Distribution
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/sign_powershell.yml
+++ b/.github/workflows/sign_powershell.yml
@@ -13,48 +13,37 @@ on:
 jobs:
   sign_scripts:
     name: Sign PowerShell scripts
-    runs-on: windows-2022
+    runs-on: windows-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
 
-      - name: Sign powershell script
-        shell: powershell
-        env:
-          PFX_CERT: ${{ secrets.PFX_CERT }}
+      - name: Configure DigiCert Signing Variables
+        shell: bash
         run: |
-          Set-Content -Value $([System.Convert]::FromBase64String($env:PFX_CERT)) -Path .\mondoo_code_signing_cert.pfx -Encoding Byte
-          
-          # sign install.sh and ensure proper encoding as UTF8 NoBOM
-          $filename = 'install.ps1'
-          $content = Get-Content $filename
-          [IO.File]::WriteAllLines($filename, $content)
-          Set-AuthenticodeSignature -Certificate (Get-PfxCertificate -FilePath .\mondoo_code_signing_cert.pfx) -FilePath $filename -TimestampServer 'http://timestamp.digicert.com' -HashAlgorithm 'SHA256'
-          (Get-AuthenticodeSignature "$filename").Status -eq 'Valid'
+          # CertLocker Authentication Certifiate
+          CERT_PATH="$(mktemp -t cert.XXX)"
+          echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > ${CERT_PATH}
+          echo "SM_CLIENT_CERT_FILE=${CERT_PATH}" >> "$GITHUB_ENV"
+          echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_CLIENT_CERT_PASSWORD }}" >> "$GITHUB_ENV"
+          # CertLocker API Key & Host
+          echo "SM_API_KEY=${{ secrets.SM_API_KEY }}" >> "$GITHUB_ENV"
+          echo "SM_HOST=${{ secrets.SM_HOST }}" >> "$GITHUB_ENV"
+          # DigiCert CertLocker Code Signing Certificate
+          echo "SM_CODE_SIGNING_CERT_SHA1_HASH=${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}" >> "$GITHUB_ENV"
+          echo "SM_CERT_ALIAS=${{ secrets.SM_CERT_ALIAS }}" >> "$GITHUB_ENV"
 
-          # sign download.sh and ensure proper encoding as UTF8 NoBOM
-          $filename = 'download.ps1'
-          $content = Get-Content $filename
-          [IO.File]::WriteAllLines($filename, $content)
-          Set-AuthenticodeSignature -Certificate (Get-PfxCertificate -FilePath .\mondoo_code_signing_cert.pfx) -FilePath $filename -TimestampServer 'http://timestamp.digicert.com' -HashAlgorithm 'SHA256'
-          (Get-AuthenticodeSignature "$filename").Status -eq 'Valid'
+      - name: Sign powershell script
+        run: |
+          jsign --storetype DIGICERTONE --alias "cert_492206180" --storepass "${SM_API_KEY}|${SM_CLIENT_CERT_FILE}|${SM_CLIENT_CERT_PASSWORD}" --tsaurl "http://timestamp.digicert.com" install.ps1
+          jsign --storetype DIGICERTONE --alias "cert_492206180" --storepass "${SM_API_KEY}|${SM_CLIENT_CERT_FILE}|${SM_CLIENT_CERT_PASSWORD}" --tsaurl "http://timestamp.digicert.com" download.ps1
+          jsign --storetype DIGICERTONE --alias "cert_492206180" --storepass "${SM_API_KEY}|${SM_CLIENT_CERT_FILE}|${SM_CLIENT_CERT_PASSWORD}" --tsaurl "http://timestamp.digicert.com" powershell/Mondoo.Installer/Mondoo.Installer.psm1
+          jsign --storetype DIGICERTONE --alias "cert_492206180" --storepass "${SM_API_KEY}|${SM_CLIENT_CERT_FILE}|${SM_CLIENT_CERT_PASSWORD}" --tsaurl "http://timestamp.digicert.com" powershell/Mondoo.Installer/Mondoo.Installer.psd1
 
-          # sign Mondoo.Installer.psm1 and ensure proper encoding as UTF8 NoBOM
-          $filename = './powershell/Mondoo.Installer/Mondoo.Installer.psm1'
-          $content = Get-Content $filename
-          [IO.File]::WriteAllLines($filename, $content)
-          Set-AuthenticodeSignature -Certificate (Get-PfxCertificate -FilePath .\mondoo_code_signing_cert.pfx) -FilePath $filename -TimestampServer 'http://timestamp.digicert.com' -HashAlgorithm 'SHA256'
-          (Get-AuthenticodeSignature "$filename").Status -eq 'Valid'
-
-          # sign Mondoo.Installer.psd1 and ensure proper encoding as UTF8 NoBOM
-          $filename = './powershell/Mondoo.Installer/Mondoo.Installer.psd1'
-          $content = Get-Content $filename
-          [IO.File]::WriteAllLines($filename, $content)
-          Set-AuthenticodeSignature -Certificate (Get-PfxCertificate -FilePath .\mondoo_code_signing_cert.pfx) -FilePath $filename -TimestampServer 'http://timestamp.digicert.com' -HashAlgorithm 'SHA256'
-          (Get-AuthenticodeSignature "$filename").Status -eq 'Valid'
-          
+      - name: Commit changes
+        run: |
           # ensure windows line-feed
-          git config --global core.autocrlf true 
+          git config --global core.autocrlf true
           # commit changes
           git config --global user.email "tools@mondoo.com"
           git config --global user.name "Mondoo Tools"
@@ -64,3 +53,7 @@ jobs:
           git add powershell/Mondoo.Installer/Mondoo.Installer.psd1
           git commit -m "Sign powershell scripts"
           git push
+
+      - name: Cleanup
+        run:
+          rm -f ${CERT_PATH}


### PR DESCRIPTION
This change switches to using our own forked actions for Mac signing and also updates the Windows Authenticode signing method.