### PR TITLE
🐞 Fixed linking issue in postinstall script

### DIFF
--- a/packages/macos/packager/darwin/scripts/postinstall
+++ b/packages/macos/packager/darwin/scripts/postinstall
@@ -13,7 +13,7 @@ chmod -R 755 .
 
 #Add application shortcuts to /usr/local/bin
 for bin in ${PRODUCT_HOME}/bin/*; do
-    ln -sf ${PRODUCT_HOME}/bin/${bin} /usr/local/bin/${bin}
+    ln -sf ${bin} /usr/local/bin/$(basename ${bin})
 done
 
 # Install Launchd:


### PR DESCRIPTION
Hi,
there was a problem with installing the package on macOS. 

The postinstall script did not create the links in `/usr/local/bin` for `cnspec` and `cnquery`. `/var/log/install.log` shows this output: 

```
2023-10-19 14:11:19+02 mbmhuth-1 installd[1114]: PackageKit (package_script_service): Preparing to execute script "./postinstall" in /private/tmp/PKInstallSandbox.P2l3cO/Scripts/com.mondoo.client.bHWA7E
2023-10-19 14:11:19+02 mbmhuth-1 package_script_service[3718]: PackageKit: Preparing to execute script "postinstall" in /tmp/PKInstallSandbox.P2l3cO/Scripts/com.mondoo.client.bHWA7E
2023-10-19 14:11:19+02 mbmhuth-1 package_script_service[3718]: Set responsibility to pid: 3320, responsible_path: /Applications/iTerm.app/Contents/MacOS/iTerm2
2023-10-19 14:11:19+02 mbmhuth-1 package_script_service[3718]: Hosted team responsibility for script set to team:(W2KUBWKG84)
2023-10-19 14:11:19+02 mbmhuth-1 package_script_service[3718]: PackageKit: Executing script "postinstall" in /tmp/PKInstallSandbox.P2l3cO/Scripts/com.mondoo.client.bHWA7E
2023-10-19 14:11:19+02 mbmhuth-1 package_script_service[3718]: ./postinstall: Post installation process started
2023-10-19 14:11:19+02 mbmhuth-1 package_script_service[3718]: ./postinstall: Change permissions in product home
2023-10-19 14:11:19+02 mbmhuth-1 package_script_service[3718]: ./postinstall: ln: /usr/local/bin//Library/Mondoo/bin/cnquery: No such file or directory
2023-10-19 14:11:19+02 mbmhuth-1 package_script_service[3718]: ./postinstall: ln: /usr/local/bin//Library/Mondoo/bin/cnspec: No such file or directory
2023-10-19 14:11:19+02 mbmhuth-1 package_script_service[3718]: ./postinstall: Installing launchd service
2023-10-19 14:11:19+02 mbmhuth-1 package_script_service[3718]: ./postinstall: Post installation process finished
```