### PR TITLE
🐞 Changed variable usage for binary linking

### DIFF
--- a/packages/macos/packager/darwin/scripts/postinstall
+++ b/packages/macos/packager/darwin/scripts/postinstall
@@ -16,7 +16,7 @@ for bin in ${PRODUCT_HOME}/bin/*; do
     binary="$(basename ${bin})"
     if [ ! -f /usr/local/bin/${binary} ]; then
         echo "Linking ${bin} to /usr/local/bin"
-        ln -sf ${PRODUCT_HOME}/bin/${bin} /usr/local/bin/${binary}
+        ln -sf ${PRODUCT_HOME}/bin/${binary} /usr/local/bin/${binary}
     else
         echo "There is an existing link for /usr/local/bin/${binary}, skipping"
     fi


### PR DESCRIPTION
After PR #369 the linking is using the a wrong variable. Changing that to the newly introduced variable `${binary}` the post install linking of the binary works now.