### PR TITLE
Introduce new optional argument to randomly delay execution

### DIFF
--- a/mdm-scripts/windows/scan.ps1
+++ b/mdm-scripts/windows/scan.ps1
@@ -22,7 +22,7 @@
     .PARAMETER LogDir
     The script output is logged to a file. Default: C:\Windows\Temp\
     .PARAMETER RandomDelay
-    Random in seconds before execution of the script
+    Random delay in seconds before execution of the script
     .EXAMPLE
     scan.ps1 -Product cnspec
     scan.ps1 -RegistrationToken 'InsertTokenHere'

--- a/mdm-scripts/windows/scan.ps1
+++ b/mdm-scripts/windows/scan.ps1
@@ -21,6 +21,8 @@
     If provided, the cnspec binary will be downloaded to the specified path. Default: C:\ProgramData\Mondoo\mondoo.yml
     .PARAMETER LogDir
     The script output is logged to a file. Default: C:\Windows\Temp\
+    .PARAMETER RandomDelay
+    Random in seconds before execution of the script
     .EXAMPLE
     scan.ps1 -Product cnspec
     scan.ps1 -RegistrationToken 'InsertTokenHere'
@@ -38,7 +40,8 @@ Param(
       [string]   $ExecutionPath = '',
       [string]   $DownloadPath = '',
       [string]   $ConfigFile = "C:\ProgramData\Mondoo\mondoo.yml",
-      [string]   $LogDir = ""
+      [string]   $LogDir = "",
+      [int]      $RandomDelay = ""
   )
 
 # Set Log location
@@ -129,7 +132,14 @@ info "Arguments:"
   info ("  DownloadPath:      {0}" -f $DownloadPath)
   info ("  ConfigFile:        {0}" -f $ConfigFile)
   info ("  LogDir:            {0}" -f $LogDir)
+  info ("  RandomDelay:       {0}" -f $RandomDelay)
   info ""
+
+if ($RandomDelay -gt 0) {
+  $delay = Get-Random -Minimum 0 -Maximum $RandomDelay
+  info ("Delaying execution by {0} seconds" -f $delay)
+  Start-Sleep -Seconds $delay
+}
 
 # Set proxy environment variables
 If (![string]::IsNullOrEmpty($Proxy)) {


### PR DESCRIPTION
The execution of ~300 parallel scans in environments with a proxy can lead to a bottleneck. 

The feature of Scheduled Tasks under Windows to randomly delay the execution is very unreliable if the task is rolled out via Group Policies. Execution may be skipped when the policies are automatically reloaded. We had clients not even reporting for 6 days in some cases. A random delay via the script has worked perfectly for us so far.