### PR TITLE
Extend the brew testing to verify if the specific cnquery/cnspec version has been installed

### DIFF
--- a/.github/workflows/test-released-all.yaml
+++ b/.github/workflows/test-released-all.yaml
@@ -27,3 +27,5 @@ jobs:
       version: ${{ github.event.inputs.version }}
   test-brew:
     uses: ./.github/workflows/test-released-brew.yaml
+    with:
+      version: ${{ github.event.inputs.version }}

--- a/.github/workflows/test-released-brew.yaml
+++ b/.github/workflows/test-released-brew.yaml
@@ -1,8 +1,19 @@
 name: "Test Release: Homebrew"
 
 on:
-  workflow_dispatch:
   workflow_call:
+    inputs:
+      version:
+        description: "Version to test"
+        required: true
+        default: "9.0.0"
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to test"
+        required: true
+        default: "9.0.0"
 
 jobs:
   formulae:
@@ -22,9 +33,17 @@ jobs:
           brew tap mondoohq/mondoo
           brew install ${{ matrix.package }}
 
+      - name: Version
+        id: version
+        run: |
+          V=${{ github.event.inputs.version }}
+          VERSION=$(echo $V | sed 's/^v//')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
       - name: Executing ${{ matrix.package }}....
         run: |
-          ${{ matrix.package }} version
+          ver= $(${{ matrix.package }} version)
+          contains(ver, ${{ steps.version.outputs.version}})
 
   cask:
     runs-on: macos-latest
@@ -38,6 +57,13 @@ jobs:
         run: |
           brew install --cask mondoohq/mondoo/mondoo
 
+      - name: Version
+        id: version
+        run: |
+          V=${{ github.event.inputs.version }}
+          VERSION=$(echo $V | sed 's/^v//')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Executing cnspec from Mondoo package....
         run: |
-          /Library/Mondoo/bin/cnspec version
+          ver=$(/Library/Mondoo/bin/cnspec version)
+          contains(ver, ${{ steps.version.outputs.version}})


### PR DESCRIPTION
We don't really verify if the *specific* cnspec version we requested has been installed. This PR attemps to tackle this for homebrew only. If this turns out to be working well, we can extend across other test workflows.