### PR TITLE
✨ Verify the right cnquery/cnspec version is installed.

### DIFF
--- a/.github/workflows/test-released-all.yaml
+++ b/.github/workflows/test-released-all.yaml
@@ -6,21 +6,27 @@ on:
       version:
         description: "Version to test"
         required: true
-        default: "8.3.0"
+        default: "9.0.0"
 
 jobs:
   test-arch:
     uses: ./.github/workflows/test-released-archlinux.yaml
+    with:
+      version: ${{ github.event.inputs.version }}
   test-docker:
     uses: ./.github/workflows/test-released-docker.yaml
+    with:
+      version: ${{ github.event.inputs.version }}
   test-install-sh:
     uses: ./.github/workflows/test-released-install-sh.yaml
     with:
       client: "cnspec"
+      version: ${{ github.event.inputs.version }}
   test-install-ps1:
     uses: ./.github/workflows/test-released-install-ps1.yaml
     with:
       client: "cnspec"
+      version: ${{ github.event.inputs.version }}
   test-osx-pkg:
     uses: ./.github/workflows/test-released-osx-pkg.yaml
     with:

--- a/.github/workflows/test-released-archlinux.yaml
+++ b/.github/workflows/test-released-archlinux.yaml
@@ -1,15 +1,31 @@
 name: "Test Release: Arch Linux"
 
 on:
-  workflow_dispatch:
   workflow_call:
+    inputs:
+      version:
+        description: "Version to test"
+        required: true
+        default: "9.0.0"
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to test"
+        required: true
+        default: "9.0.0"
 
 jobs:
   arch-cnquery-makepkg:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
+      - name: Version
+        id: version
+        run: |
+          V=${{ github.event.inputs.version }}
+          VERSION=$(echo $V | sed 's/^v//')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Install cnquery with MakePKG on Arch Linux
         run: |
           docker run --rm -v $(pwd):/work -w /work archlinux:latest \
@@ -20,13 +36,18 @@ jobs:
                     su test -c \"git clone https://aur.archlinux.org/cnquery && cd cnquery && makepkg\" && \
                     cd  cnquery && \
                     pacman -U --noconfirm  cnquery-*.zst && \
-                    cnquery version"
-
+                    cnquery version | grep -q ${{ steps.version.outputs.version }}"
+      
   arch-cnspec-yay:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
+      - name: Version
+        id: version
+        run: |
+          V=${{ github.event.inputs.version }}
+          VERSION=$(echo $V | sed 's/^v//')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Install cnspec with Yay on Arch Linux
         run: |
           docker run --rm -v $(pwd):/work -w /work archlinux:latest \
@@ -39,4 +60,4 @@ jobs:
                     cd  yay && \
                     pacman -U --noconfirm  yay-*.zst && \
                     su test -c \"yay -S --noconfirm cnspec\" && \
-                    cnspec version"
+                    cnspec version | grep -q ${{ steps.version.outputs.version }}"

--- a/.github/workflows/test-released-brew.yaml
+++ b/.github/workflows/test-released-brew.yaml
@@ -42,9 +42,10 @@ jobs:
 
       - name: Executing ${{ matrix.package }}....
         run: |
-          version=$(${{ matrix.package }} version)
-          echo $version
-          echo $version | grep -q ${{ steps.version.outputs.package_version}}
+          ${{ matrix.package }} version
+      - name: Verify the correct version is installed
+        run: |
+          ${{ matrix.package }} version | grep -q ${{ steps.version.outputs.package_version}}
 
   cask:
     runs-on: macos-latest
@@ -62,10 +63,11 @@ jobs:
         id: version
         run: |
           V=${{ github.event.inputs.version }}
-          TRIMMED=$(echo $V | sed 's/^v//')
-          echo "package_version=${TRIMMED}" >> $GITHUB_OUTPUT
+          VERSION=$(echo $V | sed 's/^v//')
+          echo "package_version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Executing cnspec from Mondoo package....
         run: |
-          version=$(/Library/Mondoo/bin/cnspec version)
-          echo $version
-          echo $version | grep -q ${{ steps.version.outputs.package_version}}
+          /Library/Mondoo/bin/cnspec version
+      - name: Verify the correct version is installed
+        run: |
+          /Library/Mondoo/bin/cnspec version | grep -q ${{ steps.version.outputs.package_version}}

--- a/.github/workflows/test-released-docker.yaml
+++ b/.github/workflows/test-released-docker.yaml
@@ -1,8 +1,19 @@
 name: "Test Release: Docker Containers"
 
 on:
-  workflow_dispatch:
   workflow_call:
+    inputs:
+      version:
+        description: "Version to test"
+        required: true
+        default: "9.0.0"
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to test"
+        required: true
+        default: "9.0.0"
 
 jobs:
   cnquery-containers:
@@ -13,12 +24,16 @@ jobs:
         tag: ["latest", "latest-ubi-rootless", "latest-rootless"]
     steps:
       - uses: actions/checkout@v4
-
+      - name: Version
+        id: version
+        run: |
+          V=${{ github.event.inputs.version }}
+          VERSION=$(echo $V | sed 's/^v//')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Testing mondoo/cnquery:${{ matrix.tag }}....
         run: |
           docker run --rm -v $(pwd):/work -w /work mondoo/cnquery:${{ matrix.tag }} \
-          version
-
+          version && version | grep -q ${{ steps.version.outputs.version }}
   cnspec-containers:
     runs-on: ubuntu-latest
     strategy:
@@ -27,11 +42,16 @@ jobs:
         tag: ["latest", "latest-ubi-rootless", "latest-rootless"]
     steps:
       - uses: actions/checkout@v4
-
+      - name: Version
+        id: version
+        run: |
+          V=${{ github.event.inputs.version }}
+          VERSION=$(echo $V | sed 's/^v//')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Testing mondoo/cnspec:${{ matrix.tag }}....
         run: |
           docker run --rm -v $(pwd):/work -w /work mondoo/cnspec:${{ matrix.tag }} \
-          version
+          version && version | grep -q ${{ steps.version.outputs.version }}
 
   mondoo-containers:
     runs-on: ubuntu-latest
@@ -41,8 +61,13 @@ jobs:
         tag: ["latest", "latest-ubi-rootless", "latest-rootless"]
     steps:
       - uses: actions/checkout@v4
-
+      - name: Version
+        id: version
+        run: |
+          V=${{ github.event.inputs.version }}
+          VERSION=$(echo $V | sed 's/^v//')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Testing mondoo/client:${{ matrix.tag }}....
         run: |
           docker run --rm -v $(pwd):/work -w /work mondoo/client:${{ matrix.tag }} \
-          version
+          version && version | grep -q ${{ steps.version.outputs.version }}

--- a/.github/workflows/test-released-install-ps1.yaml
+++ b/.github/workflows/test-released-install-ps1.yaml
@@ -7,6 +7,11 @@ on:
         required: true
         type: string
         default: "cnspec"
+      version:
+        description: "Version to test"
+        required: true
+        default: "9.0.0"
+        type: string
   workflow_dispatch:
     inputs:
       client:
@@ -16,6 +21,10 @@ on:
           - mondoo
           - cnspec
           - cnquery
+      version:
+        description: "Version to test"
+        required: true
+        default: "9.0.0"
 
 jobs:
   install-sh-windows:
@@ -25,9 +34,19 @@ jobs:
         os: ["windows-latest"]
     steps:
       - uses: actions/checkout@v4
+      - name: Version
+        id: version
+        run: |
+          V=${{ github.event.inputs.version }}
+          VERSION=$(echo $V | sed 's/^v//')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Install.sh/${{ inputs.client }} on ${{ matrix.os }}
         run: |
           Set-ExecutionPolicy Unrestricted -Scope Process -Force;
           [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
           iex ((New-Object System.Net.WebClient).DownloadString('https://install.mondoo.com/ps1/${{ inputs.client }}'));
           Install-Mondoo -Product ${{ inputs.client }};
+      - name: Verify the correct version is installed
+        run: |
+          $version = 'C:\Program Files\Mondoo\cnspec.exe' version
+          $version -like "*${{ steps.version.outputs.version }}*"

--- a/.github/workflows/test-released-install-sh.yaml
+++ b/.github/workflows/test-released-install-sh.yaml
@@ -7,6 +7,11 @@ on:
         required: true
         type: string
         default: "cnspec"
+      version:
+        description: "Version to test"
+        required: true
+        default: "9.0.0"
+        type: string
   workflow_dispatch:
     inputs:
       client:
@@ -16,6 +21,10 @@ on:
           - mondoo
           - cnspec
           - cnquery
+      version:
+        description: "Version to test"
+        required: true
+        default: "9.0.0"
 
 jobs:
   install-sh-apt:
@@ -33,11 +42,16 @@ jobs:
           ]
     steps:
       - uses: actions/checkout@v4
-
+      - name: Version
+        id: version
+        run: |
+          V=${{ github.event.inputs.version }}
+          VERSION=$(echo $V | sed 's/^v//')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Install.sh/${{ inputs.client }} on ${{ matrix.distro }}
         run: |
           docker run --rm -v $(pwd):/work -w /work ${{ matrix.distro }} \
-          bash -c "apt-get update && apt-get install -y curl && curl -sSL https://install.mondoo.com/sh/${{ inputs.client }} | bash - && ${{ inputs.client }} version"
+          bash -c "apt-get update && apt-get install -y curl && curl -sSL https://install.mondoo.com/sh/${{ inputs.client }} | bash - && ${{ inputs.client }} version | grep -q ${{ steps.version.outputs.version }}"
 
   install-sh-yum:
     runs-on: ubuntu-latest
@@ -60,11 +74,16 @@ jobs:
         ## Note: centos:8 is obsoleted by Centos Stream 9 and EOL, do not use, refer to https://www.centos.org/centos-linux-eol/
     steps:
       - uses: actions/checkout@v4
-
+      - name: Version
+        id: version
+        run: |
+          V=${{ github.event.inputs.version }}
+          VERSION=$(echo $V | sed 's/^v//')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Install.sh/${{ inputs.client }} on ${{ matrix.distro }}
         run: |
           docker run --rm -v $(pwd):/work -w /work ${{ matrix.distro }} \
-          bash -c "curl -sSL https://install.mondoo.com/sh/${{ inputs.client }} | bash - && ${{inputs.client }} version"
+          bash -c "curl -sSL https://install.mondoo.com/sh/${{ inputs.client }} | bash - && ${{inputs.client }} version | grep -q ${{ steps.version.outputs.version }}"
 
   install-sh-macos:
     runs-on: macos-latest
@@ -73,7 +92,17 @@ jobs:
         os: ["macos-latest"]
     steps:
       - uses: actions/checkout@v4
+      - name: Version
+        id: version
+        run: |
+          V=${{ github.event.inputs.version }}
+          VERSION=$(echo $V | sed 's/^v//')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Install.sh/${{ inputs.client }} on ${{ matrix.os }}
         run: |
           bash -c "$(curl -sSL https://install.mondoo.com/sh/${{ inputs.client }})"
           ${{ inputs.client }} version
+      - name: Verify the correct version is installed
+        run: |
+          ${{ inputs.client }} version | grep -q ${{ steps.version.outputs.version }}
+

--- a/.github/workflows/test-released-osx-pkg.yaml
+++ b/.github/workflows/test-released-osx-pkg.yaml
@@ -36,3 +36,6 @@ jobs:
       - name: Executing cnspec...
         run: |
           /Library/Mondoo/bin/cnspec version
+      - name: Verify the correct version is installed
+        run: |
+          /Library/Mondoo/bin/cnspec version | grep ${{ steps.version.outputs.version }}


### PR DESCRIPTION
A follow up to #405  for all the tasks we have


This verifies that the right cnspec version is present. Until now we only do `cnspec version` which does not do much in terms of asserting if the right version we requested is present. In this PR we add extra commands to check if the provided version (say 9.14.0) is present in the output when running `cnspec version`

