### PR TITLE
Rework some of the installer actions to use matrixes instead of inputs.

### DIFF
--- a/.github/workflows/test-released-all.yaml
+++ b/.github/workflows/test-released-all.yaml
@@ -20,12 +20,10 @@ jobs:
   test-install-sh:
     uses: ./.github/workflows/test-released-install-sh.yaml
     with:
-      client: "cnspec"
       version: ${{ github.event.inputs.version }}
   test-install-ps1:
     uses: ./.github/workflows/test-released-install-ps1.yaml
     with:
-      client: "cnspec"
       version: ${{ github.event.inputs.version }}
   test-osx-pkg:
     uses: ./.github/workflows/test-released-osx-pkg.yaml

--- a/.github/workflows/test-released-install-ps1.yaml
+++ b/.github/workflows/test-released-install-ps1.yaml
@@ -3,10 +3,6 @@ name: "Test Release: install.ps1"
 on:
   workflow_call:
     inputs:
-      client:
-        required: true
-        type: string
-        default: "cnspec"
       version:
         description: "Version to test"
         required: true
@@ -14,13 +10,6 @@ on:
         type: string
   workflow_dispatch:
     inputs:
-      client:
-        description: "Client to Test"
-        type: choice
-        options:
-          - mondoo
-          - cnspec
-          - cnquery
       version:
         description: "Version to test"
         required: true
@@ -32,6 +21,7 @@ jobs:
     strategy:
       matrix:
         os: ["windows-latest"]
+        package: ["cnquery", "cnspec"]
     steps:
       - uses: actions/checkout@v4
       - name: Version
@@ -40,13 +30,13 @@ jobs:
           $v='${{ github.event.inputs.version }}'
           $version=$v.trim("v","V")
           echo "version=$version" >> $env:GITHUB_OUTPUT
-      - name: Install.sh/${{ inputs.client }} on ${{ matrix.os }}
+      - name: Install.sh/${{ matrix.package }} on ${{ matrix.os }}
         run: |
           Set-ExecutionPolicy Unrestricted -Scope Process -Force;
           [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
-          iex ((New-Object System.Net.WebClient).DownloadString('https://install.mondoo.com/ps1/${{ inputs.client }}'));
-          Install-Mondoo -Product ${{ inputs.client }};
+          iex ((New-Object System.Net.WebClient).DownloadString('https://install.mondoo.com/ps1/${{ matrix.package }}'));
+          Install-Mondoo -Product ${{ matrix.package }};
       - name: Verify the correct version is installed
         run: |
-          $version=${{ inputs.client }} version
+          $version=& 'C:\Program Files\Mondoo\${{ matrix.package }}.exe' version
           $version -like "*${{ steps.version.outputs.version }}*"

--- a/.github/workflows/test-released-install-sh.yaml
+++ b/.github/workflows/test-released-install-sh.yaml
@@ -3,10 +3,6 @@ name: "Test Release: install.sh"
 on:
   workflow_call:
     inputs:
-      client:
-        required: true
-        type: string
-        default: "cnspec"
       version:
         description: "Version to test"
         required: true
@@ -14,13 +10,6 @@ on:
         type: string
   workflow_dispatch:
     inputs:
-      client:
-        description: "Client to Test"
-        type: choice
-        options:
-          - mondoo
-          - cnspec
-          - cnquery
       version:
         description: "Version to test"
         required: true
@@ -32,6 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        package: ["cnspec", "cnquery"]
         distro:
           [
             "debian:10",
@@ -48,16 +38,17 @@ jobs:
           V=${{ github.event.inputs.version }}
           VERSION=$(echo $V | sed 's/^v//')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
-      - name: Install.sh/${{ inputs.client }} on ${{ matrix.distro }}
+      - name: Install.sh/${{ matrix.package }} on ${{ matrix.distro }}
         run: |
           docker run --rm -v $(pwd):/work -w /work ${{ matrix.distro }} \
-          bash -c "apt-get update && apt-get install -y curl && curl -sSL https://install.mondoo.com/sh/${{ inputs.client }} | bash - && ${{ inputs.client }} version | grep -q ${{ steps.version.outputs.version }}"
+          bash -c "apt-get update && apt-get install -y curl && curl -sSL https://install.mondoo.com/sh/${{ matrix.package }} | bash - && ${{ matrix.package }} version | grep -q ${{ steps.version.outputs.version }}"
 
   install-sh-yum:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        package: ["cnspec", "cnquery"]
         distro:
           [
             "centos:7",
@@ -80,16 +71,17 @@ jobs:
           V=${{ github.event.inputs.version }}
           VERSION=$(echo $V | sed 's/^v//')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
-      - name: Install.sh/${{ inputs.client }} on ${{ matrix.distro }}
+      - name: Install.sh/${{ matrix.package }} on ${{ matrix.distro }}
         run: |
           docker run --rm -v $(pwd):/work -w /work ${{ matrix.distro }} \
-          bash -c "curl -sSL https://install.mondoo.com/sh/${{ inputs.client }} | bash - && ${{inputs.client }} version | grep -q ${{ steps.version.outputs.version }}"
+          bash -c "curl -sSL https://install.mondoo.com/sh/${{ matrix.package }} | bash - && ${{matrix.package }} version | grep -q ${{ steps.version.outputs.version }}"
 
   install-sh-macos:
     runs-on: macos-latest
     strategy:
       matrix:
         os: ["macos-latest"]
+        package: ["cnspec", "cnquery"]
     steps:
       - uses: actions/checkout@v4
       - name: Version
@@ -98,11 +90,11 @@ jobs:
           V=${{ github.event.inputs.version }}
           VERSION=$(echo $V | sed 's/^v//')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
-      - name: Install.sh/${{ inputs.client }} on ${{ matrix.os }}
+      - name: Install.sh/${{ matrix.package }} on ${{ matrix.os }}
         run: |
-          bash -c "$(curl -sSL https://install.mondoo.com/sh/${{ inputs.client }})"
-          ${{ inputs.client }} version
+          bash -c "$(curl -sSL https://install.mondoo.com/sh/${{ matrix.package }})"
+          ${{ matrix.package }} version
       - name: Verify the correct version is installed
         run: |
-          ${{ inputs.client }} version | grep -q ${{ steps.version.outputs.version }}
+          ${{ matrix.package }} version | grep -q ${{ steps.version.outputs.version }}
 


### PR DESCRIPTION
Instead of using an input choice, make all installers use a matrix of `[cnspec, cnquery]` packages to test both installations.