### PR TITLE
🧹 Fail powershell installer if latest version is not present.

### DIFF
--- a/.github/workflows/test-released-install-ps1.yaml
+++ b/.github/workflows/test-released-install-ps1.yaml
@@ -39,4 +39,7 @@ jobs:
       - name: Verify the correct version is installed
         run: |
           $version=& 'C:\Program Files\Mondoo\${{ matrix.package }}.exe' version
-          $version -like "*${{ steps.version.outputs.version }}*"
+          $match=$version -like "*${{ steps.version.outputs.version }}*"
+          if (-not $match) {
+            exit 1
+          }

--- a/.github/workflows/test-released-osx-pkg.yaml
+++ b/.github/workflows/test-released-osx-pkg.yaml
@@ -28,7 +28,7 @@ jobs:
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Download Package
         run: |
-          curl -SL -O https://releases.mondoo.com/mondoo/${{ steps.version.outputs.version }}/mondoo_${{ steps.version.outputs.version }}_darwin_universal.pkg
+          curl -SL -O https://releases.mondoo.com/mondoo/latest/mondoo_${{ steps.version.outputs.version }}_darwin_universal.pkg
       - name: Install Package
         run: |
           sudo installer -pkg mondoo_${{ steps.version.outputs.version }}_darwin_universal.pkg -target /


### PR DESCRIPTION
Fail the powershell script explicitly if the versions don't match