### PR TITLE
⭐ add mondoo/devkit container

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -82,6 +82,7 @@ DBp
 DBQs
 DBRUKCQg
 DEYWPOPDJc
+devkit
 Dfmno
 DGCc
 Dgoqfxz
@@ -445,6 +446,7 @@ QTq
 Qtx
 Qtxzi
 QUBl
+querypack
 QUJCWTg
 QVW
 QVZHj

--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -64,6 +64,21 @@ jobs:
             mondoo/client:${{ steps.semver.outputs.major }}
             mondoo/client:latest
 
+      - name: Build and push devkit images
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile-dev
+          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
+          push: true
+          build-args: VERSION=${{ steps.version.outputs.version }}
+          target: root
+          tags: |
+            mondoo/devkit:${{ steps.version.outputs.version }}
+            mondoo/devkit:${{ steps.semver.outputs.major }}
+            mondoo/devkit:latest
+
       - name: Build and push rootless images
         uses: docker/build-push-action@v5
         with:

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,0 +1,29 @@
+# Copyright (c) Mondoo, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+# Mondoo Multi-Architecture Container Dockerfile
+# 
+# To build root images with BuildX:   docker buildx build --build-arg VERSION=5.21.0 --platform 
+#             linux/386,linux/amd64,linux/arm/v7,linux/arm64 --target root -t mondoolabs/mondoo:5.21.0 . --push
+#
+# To build rootless images with BuildX:   docker buildx build --build-arg VERSION=5.21.0 --platform 
+#             linux/386,linux/amd64,linux/arm/v7,linux/arm64 --target rootless -t mondoolabs/mondoo:5.21.0 . --push
+
+ARG VERSION
+FROM docker.io/mondoo/cnspec:${VERSION} AS root
+WORKDIR /mnt
+
+RUN ln -s /usr/local/bin/cnspec /usr/local/bin/mondoo
+# force the installation of all providers that the linter needs
+RUN touch empty.mql.yaml && cnspec bundle lint empty.mql.yaml && rm $(find /opt/mondoo/providers -not -name "*.json" -type f)
+RUN mkdir -p /home/mondoo/.config/mondoo && echo "auto_update: false" > /home/mondoo/.config/mondoo/mondoo.yaml
+
+ENTRYPOINT [ "cnspec" ]
+CMD ["bundle", "lint"]
+
+# Rootless version of the container
+FROM root AS rootless
+
+RUN addgroup -S mondoo && adduser -S -G mondoo mondoo
+USER mondoo
+

--- a/dockerhub/mondoo/client.md
+++ b/dockerhub/mondoo/client.md
@@ -11,6 +11,7 @@
 * Where to file issues: https://github.com/mondoohq/installer/issues
 * cnquery & cnspec binary & package downloads (Non-Container):  https://releases.mondoo.com/
 * Supported Architectures: `amd64`, `arm64`, `i386`, `arm32v6`, `arm32v7`
+* A `devkit` container for policy/querypack development: ```docker run -v ${PWD}:/mnt -it mondoo/devkit bundle lint bundle.mql.yaml```
 
 ## Supported tags
 


### PR DESCRIPTION
Purpose-built for MQL, policy and querypack development, this container comes with all providers for compiling and linting, but none of the size. It removes all binaries for providers and focuses on linting and validation requirements (ie schemas).