### PR TITLE
Upgrade Wix to 3.14

### DIFF
--- a/packages/msi/msi/Mondoo MSI.wixproj
+++ b/packages/msi/msi/Mondoo MSI.wixproj
@@ -45,7 +45,7 @@
   <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
   <Target Name="EnsureWixToolsetInstalled" Condition=" '$(WixTargetsImported)' != 'true' ">
-    <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
+    <Error Text="The WiX Toolset v3.14 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
   </Target>
   <!--
 	To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/packages/msi/package.ps1
+++ b/packages/msi/package.ps1
@@ -22,7 +22,7 @@ cd msi
 Remove-Item .\Product.wixobj -ErrorAction Ignore
 Remove-Item .\mondoo.wixpdb -ErrorAction Ignore
 # build package
-dir 'C:\Program Files (x86)\WiX Toolset v3.11\bin'
+dir 'C:\Program Files (x86)\'
 info "run candle (standard)"
 & 'C:\Program Files (x86)\WiX Toolset v3.11\bin\candle' -nologo -arch x64 -dMondooSKU="standard" -dProductVersion="$version" -ext WixUtilExtension Product.wxs
 

--- a/packages/msi/package.ps1
+++ b/packages/msi/package.ps1
@@ -24,10 +24,10 @@ Remove-Item .\mondoo.wixpdb -ErrorAction Ignore
 # build package
 dir 'C:\Program Files (x86)\'
 info "run candle (standard)"
-& 'C:\Program Files (x86)\WiX Toolset v3.11\bin\candle' -nologo -arch x64 -dMondooSKU="standard" -dProductVersion="$version" -ext WixUtilExtension Product.wxs
+& 'C:\Program Files (x86)\WiX Toolset v3.14\bin\candle' -nologo -arch x64 -dMondooSKU="standard" -dProductVersion="$version" -ext WixUtilExtension Product.wxs
 
 info "run light (standard)"
-& 'C:\Program Files (x86)\WiX Toolset v3.11\bin\light' -nologo -dcl:high -cultures:en-us -loc en-us.wxl -ext WixUIExtension -ext WixUtilExtension product.wixobj -o mondoo.msi
+& 'C:\Program Files (x86)\WiX Toolset v3.14\bin\light' -nologo -dcl:high -cultures:en-us -loc en-us.wxl -ext WixUIExtension -ext WixUtilExtension product.wixobj -o mondoo.msi
 
 # delete previous intermediate files
 Remove-Item .\Product.wixobj -ErrorAction Ignore

--- a/packages/msi/package.ps1
+++ b/packages/msi/package.ps1
@@ -22,6 +22,7 @@ cd msi
 Remove-Item .\Product.wixobj -ErrorAction Ignore
 Remove-Item .\mondoo.wixpdb -ErrorAction Ignore
 # build package
+dir 'C:\Program Files (x86)\WiX Toolset v3.11\bin'
 info "run candle (standard)"
 & 'C:\Program Files (x86)\WiX Toolset v3.11\bin\candle' -nologo -arch x64 -dMondooSKU="standard" -dProductVersion="$version" -ext WixUtilExtension Product.wxs
 


### PR DESCRIPTION
MSI builds are failing because Wix 3.11 isn't installed, the problem was that the runners are now including Wix 3.14, so this PR just updates the path to the Wix tools _candle_ and _light_.