### PR TITLE
Push SBOM/Provenance data to Docker Hub

### DIFF
--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -51,6 +51,8 @@ jobs:
       - name: Build and push root images
         uses: docker/build-push-action@v5
         with:
+          sbom: true
+          provenance: true
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
@@ -69,6 +71,8 @@ jobs:
         continue-on-error: true
         uses: docker/build-push-action@v5
         with:
+          sbom: true
+          provenance: true
           context: .
           file: Dockerfile-dev
           platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
@@ -83,6 +87,8 @@ jobs:
       - name: Build and push rootless images
         uses: docker/build-push-action@v5
         with:
+          sbom: true
+          provenance: true
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
           push: true
@@ -96,6 +102,8 @@ jobs:
       - name: Build and push root images (ubi)
         uses: docker/build-push-action@v5
         with:
+          sbom: true
+          provenance: true
           context: .
           file: Dockerfile-ubi
           platforms: linux/amd64,linux/arm64
@@ -110,6 +118,8 @@ jobs:
       - name: Build and push rootless images (ubi)
         uses: docker/build-push-action@v5
         with:
+          sbom: true
+          provenance: true
           context: .
           file: Dockerfile-ubi
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
With this change we will have build data in the image manifest which can be pulled by tools (like ours) or via the CLI with commands like `docker buildx imagetools inspect mondoo/cnspec --format "{{json .Provenance}}"` or `docker buildx imagetools inspect mondoo/cnspec --format "{{ json .SBOM }}"`

To see an example of what this data will look like pull this container where I just made the same change

```
docker buildx imagetools inspect dokken/ubuntu-24.04 --format "{{json .Provenance}}"
docker buildx imagetools inspect dokken/ubuntu-24.04 --format "{{ json .SBOM }}"
```