### PR TITLE
🧹 Remove CentOS 7 from tests

### DIFF
--- a/.github/workflows/test-released-install-sh.yaml
+++ b/.github/workflows/test-released-install-sh.yaml
@@ -51,7 +51,6 @@ jobs:
         package: ["cnspec", "cnquery"]
         distro:
           [
-            "centos:7",
             "quay.io/centos/centos:stream9",
             "fedora:38",
             "fedora:39",


### PR DESCRIPTION
It is EOL.