### PR TITLE
Enable bash debug in actions for .deb-based distros for issue #477

### DIFF
--- a/.github/workflows/check_certificate_not_expired.yml
+++ b/.github/workflows/check_certificate_not_expired.yml
@@ -16,7 +16,7 @@ jobs:
         shell: bash
         run: |
           echo Installing Mondoo cnspec...
-          bash -c "$(curl -sSL https://install.mondoo.com/sh/cnspec)"
+          bash -xc "$(curl -sSL https://install.mondoo.com/sh/cnspec)"
 
       - name: Check expiration of public-code-signing.cer
         shell: bash

--- a/.github/workflows/check_gpg_key_not_expired.yml
+++ b/.github/workflows/check_gpg_key_not_expired.yml
@@ -17,7 +17,7 @@ jobs:
         shell: bash
         run: |
           echo Installing Mondoo cnspec...
-          bash -c "$(curl -sSL https://install.mondoo.com/sh/cnspec)"
+          bash -xc "$(curl -sSL https://install.mondoo.com/sh/cnspec)"
       
       - name: Check expiration of public-package-signing.gpg
         shell: bash

--- a/.github/workflows/test-released-install-sh.yaml
+++ b/.github/workflows/test-released-install-sh.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Install.sh/${{ matrix.package }} on ${{ matrix.distro }}
         run: |
           docker run --rm -v $(pwd):/work -w /work ${{ matrix.distro }} \
-          bash -c "apt-get update && apt-get install -y curl && curl -sSL https://install.mondoo.com/sh/${{ matrix.package }} | bash - && ${{ matrix.package }} version | grep -q ${{ steps.version.outputs.version }}"
+          bash -c "apt-get update && apt-get install -y curl && curl -sSL https://install.mondoo.com/sh/${{ matrix.package }} | bash -x - && ${{ matrix.package }} version | grep -q ${{ steps.version.outputs.version }}"
 
   install-sh-yum:
     runs-on: ubuntu-latest


### PR DESCRIPTION
There is an intermittent issue where the installer will not detect deb-based distros properly, attempting to understand when this happens