### PR TITLE
Build arm64 MSI packages additionally to the current amd64 ones

### DIFF
--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -151,7 +151,7 @@ jobs:
           echo " - Signing MSI..."
           Set-Location -Path '.\..\..'
           signtool.exe sign /debug /sha1 ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 .\packages\msi\mondoo_${{ matrix.arch }}.msi
-          Copy-Item '.\packages\msi\mondoo_${{ matrix.arch }}.msi' '.\dist\'
+          Copy-Item '.\packages\msi\mondoo_${{ matrix.arch }}.msi' '.\dist\${{ matrix.arch }}'
       - name: Dump Signing Log on Failure
         if: failure()
         run: |
@@ -177,6 +177,9 @@ jobs:
 
   publish:
     name: 'Publish: Releases'
+    strategy:
+      matrix:
+        arch: ["amd64", "arm64"]
     needs: [setup,msi-build]
     if: ${{ ! inputs.skip-publish }}
     runs-on: ubuntu-latest
@@ -186,7 +189,7 @@ jobs:
       - name: Download MSI Package
         uses: actions/download-artifact@v4
         with:
-          name: msi
+          name: msi-${{ matrix.arch }}
           path: dist
       - name: Authenticate with Google Cloud
         id: gauth

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -54,9 +54,9 @@ jobs:
       - name: Ensure version of cnquery and cnspec are available
         run: |
           curl -sL --head --fail https://github.com/mondoohq/cnquery/releases/download/v${{ steps.version.outputs.version }}/cnquery_${{ steps.version.outputs.version }}_windows_amd64.zip \
-            https://github.com/mondoohq/cnspec/releases/download/v${{ steps.version.outputs.version }}/cnquery_${{ steps.version.outputs.version }}_windows_amd64.zip \
+            https://github.com/mondoohq/cnspec/releases/download/v${{ steps.version.outputs.version }}/cnspec${{ steps.version.outputs.version }}_windows_amd64.zip \
             https://github.com/mondoohq/cnquery/releases/download/v${{ steps.version.outputs.version }}/cnquery_${{ steps.version.outputs.version }}_windows_arm64.zip \
-            https://github.com/mondoohq/cnspec/releases/download/v${{ steps.version.outputs.version }}/cnquery_${{ steps.version.outputs.version }}_windows_arm64.zip
+            https://github.com/mondoohq/cnspec/releases/download/v${{ steps.version.outputs.version }}/cnspec_${{ steps.version.outputs.version }}_windows_arm64.zip
 
 
   dist-prepare:

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -24,9 +24,9 @@ jobs:
     name: 'Setup'
     runs-on: ubuntu-latest
     outputs:
-      version: 11.26.0
-      trimmed-version: 11.26.0
-      name: charismatic chisel
+      version: ${{ steps.version.outputs.version }}
+      trimmed-version: ${{ steps.version.outputs.trimmed_version }}
+      name: ${{ steps.version.outputs.name }}
     steps:
       - name: Set Version (Workflow Dispatch)
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -103,8 +103,8 @@ jobs:
       - name: Download Distribution
         uses: actions/download-artifact@v4
         with:
-          name: dist-${{ matrix.arch }}/
-          path: dist/${{ matrix.arch }}/
+          name: dist-${{ matrix.arch }}
+          path: dist/${{ matrix.arch }}
 
       - name: Setup Certificate
         shell: bash

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -166,8 +166,8 @@ jobs:
 
       - name: Cleanup dist before upload
         run: |
-          Remove-Item -Path .\dist\cnquery.exe -Force
-          Remove-Item -Path .\dist\cnspec.exe -Force
+          Remove-Item -Path .\dist\${{ matrix.arch }}\cnquery.exe -Force
+          Remove-Item -Path .\dist\${{ matrix.arch }}\cnspec.exe -Force
 
       - name: Upload Distribution
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -150,8 +150,8 @@ jobs:
           # sign msi package
           echo " - Signing MSI..."
           Set-Location -Path '.\..\..'
-          signtool.exe sign /debug /sha1 ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 .\packages\msi\mondoo_${{ matrix.arch }}.exe
-          Copy-Item '.\packages\msi\mondoo_${{ matrix.arch }}.exe' '.\dist\${{ matrix.arch }}'
+          signtool.exe sign /debug /sha1 ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 .\packages\msi\mondoo_${{ matrix.arch }}.msi
+          Copy-Item '.\packages\msi\mondoo_${{ matrix.arch }}.msi' '.\dist\${{ matrix.arch }}'
       - name: Dump Signing Log on Failure
         if: failure()
         run: |
@@ -208,10 +208,10 @@ jobs:
           VERSION: ${{ needs.setup.outputs.version }}
         run: |
           cd dist
-          mv mondoo_${{ matrix.arch }}.exe mondoo_${VERSION}_windows_${{ matrix.arch }}.exe
-          sha256sum mondoo_${VERSION}_windows_${{ matrix.arch }}.exe >> checksums.windows_${{ matrix.arch }}.txt
+          mv mondoo_${{ matrix.arch }}.msi mondoo_${VERSION}_windows_${{ matrix.arch }}.msi
+          sha256sum mondoo_${VERSION}_windows_${{ matrix.arch }}.msi >> checksums.windows_${{ matrix.arch }}.txt
           gsutil cp checksums.windows_${{ matrix.arch }}.txt gs://releases-us.mondoo.io/mondoo/${VERSION}/checksums.windows_${{ matrix.arch }}.txt
-          gsutil cp mondoo_${VERSION}_windows_${{ matrix.arch }}.exe gs://releases-us.mondoo.io/mondoo/${VERSION}/mondoo_${VERSION}_windows_${{ matrix.arch }}.exe
+          gsutil cp mondoo_${VERSION}_windows_${{ matrix.arch }}.msi gs://releases-us.mondoo.io/mondoo/${VERSION}/mondoo_${VERSION}_windows_${{ matrix.arch }}.msi
       - name: Reindex folder on releaser.mondoo.com
         uses: peter-evans/repository-dispatch@v3
         env:

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -150,8 +150,8 @@ jobs:
           # sign msi package
           echo " - Signing MSI..."
           Set-Location -Path '.\..\..'
-          signtool.exe sign /debug /sha1 ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 .\packages\msi\mondoo_${{ matrix.arch }}.msi
-          Copy-Item '.\packages\msi\mondoo_${{ matrix.arch }}.msi' '.\dist\${{ matrix.arch }}'
+          signtool.exe sign /debug /sha1 ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 .\packages\msi\mondoo_${{ matrix.arch }}.exe
+          Copy-Item '.\packages\msi\mondoo_${{ matrix.arch }}.exe' '.\dist\${{ matrix.arch }}'
       - name: Dump Signing Log on Failure
         if: failure()
         run: |
@@ -208,10 +208,10 @@ jobs:
           VERSION: ${{ needs.setup.outputs.version }}
         run: |
           cd dist
-          mv mondoo_${{ matrix.arch }}.msi mondoo_${VERSION}_windows_${{ matrix.arch }}.msi
-          sha256sum mondoo_${VERSION}_windows_${{ matrix.arch }}.msi >> checksums.windows_${{ matrix.arch }}.txt
+          mv mondoo_${{ matrix.arch }}.exe mondoo_${VERSION}_windows_${{ matrix.arch }}.exe
+          sha256sum mondoo_${VERSION}_windows_${{ matrix.arch }}.exe >> checksums.windows_${{ matrix.arch }}.txt
           gsutil cp checksums.windows_${{ matrix.arch }}.txt gs://releases-us.mondoo.io/mondoo/${VERSION}/checksums.windows_${{ matrix.arch }}.txt
-          gsutil cp mondoo_${VERSION}_windows_${{ matrix.arch }}.msi gs://releases-us.mondoo.io/mondoo/${VERSION}/mondoo_${VERSION}_windows_${{ matrix.arch }}.msi
+          gsutil cp mondoo_${VERSION}_windows_${{ matrix.arch }}.exe gs://releases-us.mondoo.io/mondoo/${VERSION}/mondoo_${VERSION}_windows_${{ matrix.arch }}.exe
       - name: Reindex folder on releaser.mondoo.com
         uses: peter-evans/repository-dispatch@v3
         env:

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -53,10 +53,10 @@ jobs:
           echo "trimmed_version=$(echo ${V} | sed 's/-.*//')" >> $GITHUB_OUTPUT
       - name: Ensure version of cnquery and cnspec are available
         run: |
-          curl -sL --head --fail https://github.com/mondoohq/cnquery/releases/download/v11.26.0/cnquery_11.26.0_windows_amd64.zip \
-            https://github.com/mondoohq/cnspec/releases/download/v11.26.0/cnspec_11.26.0_windows_amd64.zip \
-            https://github.com/mondoohq/cnquery/releases/download/v11.26.0/cnquery_11.26.0_windows_arm64.zip \
-            https://github.com/mondoohq/cnspec/releases/download/v11.26.0/cnspec_11.26.0_windows_arm64.zip
+          curl -sL --head --fail https://github.com/mondoohq/cnquery/releases/download/v${{ steps.version.outputs.version }}/cnquery_${{ steps.version.outputs.version }}_windows_amd64.zip \
+            https://github.com/mondoohq/cnspec/releases/download/v${{ steps.version.outputs.version }}/cnquery_${{ steps.version.outputs.version }}_windows_amd64.zip \
+            https://github.com/mondoohq/cnquery/releases/download/v${{ steps.version.outputs.version }}/cnquery_${{ steps.version.outputs.version }}_windows_arm64.zip \
+            https://github.com/mondoohq/cnspec/releases/download/v${{ steps.version.outputs.version }}/cnquery_${{ steps.version.outputs.version }}_windows_arm64.zip
 
 
   dist-prepare:

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -150,7 +150,7 @@ jobs:
           # sign msi package
           echo " - Signing MSI..."
           Set-Location -Path '.\..\..'
-          signtool.exe sign /debug /sha1 ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 .\packages\msi\mondoo.msi
+          signtool.exe sign /debug /sha1 ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 .\packages\msi\mondoo_${{ matrix.arch }}.msi
           Copy-Item '.\packages\msi\mondoo_${{ matrix.arch }}.msi' '.\dist\'
       - name: Dump Signing Log on Failure
         if: failure()

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -24,9 +24,9 @@ jobs:
     name: 'Setup'
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.version.outputs.version }}
-      trimmed-version: ${{ steps.version.outputs.trimmed_version }}
-      name: ${{ steps.version.outputs.name }}
+      version: 11.26.0
+      trimmed-version: 11.26.0
+      name: charismatic chisel
     steps:
       - name: Set Version (Workflow Dispatch)
         if: github.event_name == 'workflow_dispatch'
@@ -53,12 +53,17 @@ jobs:
           echo "trimmed_version=$(echo ${V} | sed 's/-.*//')" >> $GITHUB_OUTPUT
       - name: Ensure version of cnquery and cnspec are available
         run: |
-          curl -sL --head --fail https://github.com/mondoohq/cnquery/releases/download/v${{ steps.version.outputs.version }}/cnquery_${{ steps.version.outputs.version }}_windows_amd64.zip
-          curl -sL --head --fail https://github.com/mondoohq/cnspec/releases/download/v${{ steps.version.outputs.version }}/cnspec_${{ steps.version.outputs.version }}_windows_amd64.zip
+          curl -sL --head --fail https://github.com/mondoohq/cnquery/releases/download/v11.26.0/cnquery_11.26.0_windows_amd64.zip \
+            https://github.com/mondoohq/cnspec/releases/download/v11.26.0/cnspec_11.26.0_windows_amd64.zip \
+            https://github.com/mondoohq/cnquery/releases/download/v11.26.0/cnquery_11.26.0_windows_arm64.zip \
+            https://github.com/mondoohq/cnspec/releases/download/v11.26.0/cnspec_11.26.0_windows_arm64.zip
 
 
   dist-prepare:
     name: 'Prepare Distribution for Packaging'
+    strategy:
+      matrix:
+        arch: ["amd64", "arm64"]
     runs-on: ubuntu-latest
     needs: setup
     steps:
@@ -70,12 +75,12 @@ jobs:
         run: |
           # TODO: We should check the sums here
           mkdir -p dist && cd dist
-          curl -sSL -O https://github.com/mondoohq/cnspec/releases/download/v${VERSION}/cnspec_${VERSION}_windows_amd64.zip
-          unzip cnspec_${VERSION}_windows_amd64.zip
-          rm cnspec_${VERSION}_windows_amd64.zip
-          curl -sSL -O https://github.com/mondoohq/cnquery/releases/download/v${VERSION}/cnquery_${VERSION}_windows_amd64.zip
-          unzip cnquery_${VERSION}_windows_amd64.zip
-          rm cnquery_${VERSION}_windows_amd64.zip
+          curl -sSL -O https://github.com/mondoohq/cnspec/releases/download/v${VERSION}/cnspec_${VERSION}_windows_${{ matrix.arch }}.zip
+          unzip cnspec_${VERSION}_windows_${{ matrix.arch }}.zip
+          rm cnspec_${VERSION}_windows_${{ matrix.arch }}.zip
+          curl -sSL -O https://github.com/mondoohq/cnquery/releases/download/v${VERSION}/cnquery_${VERSION}_windows_${{ matrix.arch }}.zip
+          unzip cnquery_${VERSION}_windows_${{ matrix.arch }}.zip
+          rm cnquery_${VERSION}_windows_${{ matrix.arch }}.zip
           ls -lh
       - name: Upload Distribution
         uses: actions/upload-artifact@v4
@@ -87,6 +92,9 @@ jobs:
   msi-build:
     name: 'Packaging: Windows MSI'
     runs-on: windows-latest
+    strategy:
+      matrix:
+        arch: ["amd64", "arm64"]
     needs: [ setup, dist-prepare ]
     #  For Version: ${{ needs.setup.outputs.version }}
     steps:
@@ -95,8 +103,8 @@ jobs:
       - name: Download Distribution
         uses: actions/download-artifact@v4
         with:
-          name: dist
-          path: dist
+          name: dist/${{ matrix.arch }}/
+          path: dist/${{ matrix.arch }}/
 
       - name: Setup Certificate
         shell: bash
@@ -131,19 +139,19 @@ jobs:
         run: |
           $mondooVersion = ${env:VERSION}
           echo "Running build job for version ${mondooVersion}"
-          Copy-Item .\dist\cnquery.exe .\packages\msi\msi\
-          Copy-Item .\dist\cnspec.exe .\packages\msi\msi\
-          Copy-Item .\dist\cnquery.exe .\packages\msi\appx\
-          Copy-Item .\dist\cnspec.exe .\packages\msi\appx\
+          Copy-Item .\dist\${{ matrix.arch }}\cnquery.exe .\packages\msi\msi\
+          Copy-Item .\dist\${{ matrix.arch }}\cnspec.exe .\packages\msi\msi\
+          Copy-Item .\dist\${{ matrix.arch }}\cnquery.exe .\packages\msi\appx\
+          Copy-Item .\dist\${{ matrix.arch }}\cnspec.exe .\packages\msi\appx\
           # build msi package
           echo " - Packaging MSI..."
           Set-Location -Path '.\packages\msi\'
-          ./package.ps1 -version $mondooVersion
+          ./package.ps1 -version $mondooVersion -arch ${{ matrix.arch }}
           # sign msi package
           echo " - Signing MSI..."
           Set-Location -Path '.\..\..'
           signtool.exe sign /debug /sha1 ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 .\packages\msi\mondoo.msi
-          Copy-Item '.\packages\msi\mondoo.msi' '.\dist\'
+          Copy-Item '.\packages\msi\mondoo_${{ matrix.arch }}.msi' '.\dist\'
       - name: Dump Signing Log on Failure
         if: failure()
         run: |
@@ -197,10 +205,10 @@ jobs:
           VERSION: ${{ needs.setup.outputs.version }}
         run: |
           cd dist
-          mv mondoo.msi mondoo_${VERSION}_windows_amd64.msi
-          sha256sum mondoo_${VERSION}_windows_amd64.msi >> checksums.windows.txt
-          gsutil cp checksums.windows.txt gs://releases-us.mondoo.io/mondoo/${VERSION}/checksums.windows.txt
-          gsutil cp mondoo_${VERSION}_windows_amd64.msi gs://releases-us.mondoo.io/mondoo/${VERSION}/mondoo_${VERSION}_windows_amd64.msi
+          mv mondoo_${{ matrix.arch }}.msi mondoo_${VERSION}_windows_${{ matrix.arch }}.msi
+          sha256sum mondoo_${VERSION}_windows_${{ matrix.arch }}.msi >> checksums.windows_${{ matrix.arch }}.txt
+          gsutil cp checksums.windows_${{ matrix.arch }}.txt gs://releases-us.mondoo.io/mondoo/${VERSION}/checksums.windows_${{ matrix.arch }}.txt
+          gsutil cp mondoo_${VERSION}_windows_${{ matrix.arch }}.msi gs://releases-us.mondoo.io/mondoo/${VERSION}/mondoo_${VERSION}_windows_${{ matrix.arch }}.msi
       - name: Reindex folder on releaser.mondoo.com
         uses: peter-evans/repository-dispatch@v3
         env:

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -74,7 +74,7 @@ jobs:
           VERSION: ${{ needs.setup.outputs.version }}
         run: |
           # TODO: We should check the sums here
-          mkdir -p dist && cd dist
+          mkdir -p dist/${{ matrix.arch }} && cd dist/${{ matrix.arch }}
           curl -sSL -O https://github.com/mondoohq/cnspec/releases/download/v${VERSION}/cnspec_${VERSION}_windows_${{ matrix.arch }}.zip
           unzip cnspec_${VERSION}_windows_${{ matrix.arch }}.zip
           rm cnspec_${VERSION}_windows_${{ matrix.arch }}.zip

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Ensure version of cnquery and cnspec are available
         run: |
           curl -sL --head --fail https://github.com/mondoohq/cnquery/releases/download/v${{ steps.version.outputs.version }}/cnquery_${{ steps.version.outputs.version }}_windows_amd64.zip \
-            https://github.com/mondoohq/cnspec/releases/download/v${{ steps.version.outputs.version }}/cnspec${{ steps.version.outputs.version }}_windows_amd64.zip \
+            https://github.com/mondoohq/cnspec/releases/download/v${{ steps.version.outputs.version }}/cnspec_${{ steps.version.outputs.version }}_windows_amd64.zip \
             https://github.com/mondoohq/cnquery/releases/download/v${{ steps.version.outputs.version }}/cnquery_${{ steps.version.outputs.version }}_windows_arm64.zip \
             https://github.com/mondoohq/cnspec/releases/download/v${{ steps.version.outputs.version }}/cnspec_${{ steps.version.outputs.version }}_windows_arm64.zip
 

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -85,8 +85,8 @@ jobs:
       - name: Upload Distribution
         uses: actions/upload-artifact@v4
         with:
-          name: dist
-          path: dist
+          name: dist-${{ matrix.arch }}
+          path: dist/${{ matrix.arch }}
 
 
   msi-build:
@@ -103,7 +103,7 @@ jobs:
       - name: Download Distribution
         uses: actions/download-artifact@v4
         with:
-          name: dist/${{ matrix.arch }}/
+          name: dist-${{ matrix.arch }}/
           path: dist/${{ matrix.arch }}/
 
       - name: Setup Certificate
@@ -172,8 +172,8 @@ jobs:
       - name: Upload Distribution
         uses: actions/upload-artifact@v4
         with:
-          name: msi
-          path: dist/
+          name: msi-${{ matrix.arch }}
+          path: dist/${{ matrix.arch }}
 
   publish:
     name: 'Publish: Releases'

--- a/packages/msi/msi/Product.wxs
+++ b/packages/msi/msi/Product.wxs
@@ -7,18 +7,18 @@
 <?define UpgradeCodeStandard = "b0fee933-ccd2-467c-8fe4-bb0ac6a099c8" ?>
 <?define UpgradeCodeEnterprise = "4ABDD5C7-E1E1-41A6-8119-DCE65634A6CC" ?>
 <?define UpgradeCodeArm64 = "090cfb7d-c00c-4d36-94fe-f649a4b29c91" ?>
-<?if $(var.arch) = "arm64" ?>
-<?define UpgradeCode = "$(var.UpgradeCodeArm64)" ?>
-<?define InstallerVersion="500" ?>
-<? else ?>
-<?define InstallerVersion="200" ?>
-<?if $(var.MondooSKU) = "standard" ?>
+<?if $(var.arch) = "arm64"?>
+<?define UpgradeCode = "$(var.UpgradeCodeArm64)"?>
+<?define InstallerVersion="500"?>
+<?else?>
+<?define InstallerVersion="200"?>
+<?if $(var.MondooSKU) = "standard"?>
 <?define UpgradeCode = "$(var.UpgradeCodeStandard)"?>
 <?define ProductName = "Mondoo"?>
 <?define ServiceInstallStart = "demand" ?>
 <?define RegistrationTokenRequired = "0"?>
 <?define OtherSKU = "$(var.UpgradeCodeEnterprise)"?>
-<?elseif $(var.MondooSKU) = "enterprise" ?>
+<?elseif $(var.MondooSKU) = "enterprise"?>
 <?define UpgradeCode = "$(var.UpgradeCodeEnterprise)"?>
 <?define ProductName = "Mondoo Enterprise"?>
 <?define ServiceInstallStart = "auto" ?>

--- a/packages/msi/msi/Product.wxs
+++ b/packages/msi/msi/Product.wxs
@@ -10,6 +10,10 @@
 <?if $(var.arch) = "arm64"?>
 <?define UpgradeCode = "$(var.UpgradeCodeArm64)"?>
 <?define InstallerVersion="500"?>
+<?define ProductName = "Mondoo"?>
+<?define ServiceInstallStart = "demand" ?>
+<?define RegistrationTokenRequired = "0"?>
+<?define OtherSKU = "$(var.UpgradeCodeEnterprise)"?>
 <?else?>
 <?define InstallerVersion="200"?>
 <?if $(var.MondooSKU) = "standard"?>

--- a/packages/msi/msi/Product.wxs
+++ b/packages/msi/msi/Product.wxs
@@ -27,6 +27,7 @@
 <?else?>
 <?error MondooSKU must be defined as one of "standard" or "enterprise" ?>
 <?endif?>
+<?endif?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
   xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
   <Product Name="$(var.ProductName)" Version="$(var.ProductVersion)" Manufacturer="Mondoo, Inc." Language="1033" Codepage="1252" Id="*" UpgradeCode="$(var.UpgradeCode)">

--- a/packages/msi/msi/Product.wxs
+++ b/packages/msi/msi/Product.wxs
@@ -6,6 +6,12 @@
 
 <?define UpgradeCodeStandard = "b0fee933-ccd2-467c-8fe4-bb0ac6a099c8" ?>
 <?define UpgradeCodeEnterprise = "4ABDD5C7-E1E1-41A6-8119-DCE65634A6CC" ?>
+<?define UpgradeCodeArm64 = "090cfb7d-c00c-4d36-94fe-f649a4b29c91" ?>
+<?if $(var.arch) = "arm64" ?>
+<?define UpgradeCode = "$(var.UpgradeCodeArm64)" ?>
+<?define InstallerVersion="500" ?>
+<? else ?>
+<?define InstallerVersion="200" ?>
 <?if $(var.MondooSKU) = "standard" ?>
 <?define UpgradeCode = "$(var.UpgradeCodeStandard)"?>
 <?define ProductName = "Mondoo"?>
@@ -28,7 +34,7 @@
     <Package
       Description="Mondoo verifies your system for known vulnerabilities"
       Manufacturer="Mondoo, Inc."
-      InstallerVersion="200"
+      InstallerVersion="$(var.InstallerVersion)"
       Compressed="yes"
       Comments="Windows Installer Package"
       Platform="x64"

--- a/packages/msi/msi/Product.wxs
+++ b/packages/msi/msi/Product.wxs
@@ -42,7 +42,6 @@
       InstallerVersion="$(var.InstallerVersion)"
       Compressed="yes"
       Comments="Windows Installer Package"
-      Platform="x64"
       InstallScope="perMachine"
       InstallPrivileges="elevated"
       />

--- a/packages/msi/package.ps1
+++ b/packages/msi/package.ps1
@@ -19,6 +19,7 @@ function info($msg) {  Write-Host $msg -f white }
 
 info "build msi package $version"
 # delete previous build
+Remove-Item ".\mondoo.msi" -ErrorAction Ignore
 Remove-Item ".\mondoo_${arch}.msi" -ErrorAction Ignore
 cd msi
 # delete previous intermediate files
@@ -27,7 +28,7 @@ Remove-Item .\mondoo.wixpdb -ErrorAction Ignore
 # build package
 dir 'C:\Program Files (x86)\'
 info "run candle (standard)"
-& 'C:\Program Files (x86)\WiX Toolset v3.14\bin\candle' -nologo  -dMondooSKU="standard" -darch="$platform" -dProductVersion="$version" -ext WixUtilExtension Product.wxs
+& 'C:\Program Files (x86)\WiX Toolset v3.14\bin\candle' -nologo -dMondooSKU="standard" -darch="$platform" -dProductVersion="$version" -ext WixUtilExtension Product.wxs
 
 info "run light (standard)"
 

--- a/packages/msi/package.ps1
+++ b/packages/msi/package.ps1
@@ -6,6 +6,7 @@ param (
     [string]$version = 'x.xx.x',
     [string]$arch = 'amd64|arm64'
 )
+Set-PSDebug -Trace 1
 
 $platform = $arch -eq "amd64" ? "x64" : $arch
 
@@ -30,6 +31,7 @@ info "run candle (standard)"
 & 'C:\Program Files (x86)\WiX Toolset v3.14\bin\candle' -nologo  -dMondooSKU="standard" -darch="$platform" -dProductVersion="$version" -ext WixUtilExtension Product.wxs
 
 info "run light (standard)"
+
 & 'C:\Program Files (x86)\WiX Toolset v3.14\bin\light' -nologo -dcl:high -cultures:en-us -loc en-us.wxl -ext WixUIExtension -ext WixUtilExtension product.wixobj -o "mondoo_${platform}.msi"
 
 # delete previous intermediate files

--- a/packages/msi/package.ps1
+++ b/packages/msi/package.ps1
@@ -19,7 +19,7 @@ function info($msg) {  Write-Host $msg -f white }
 
 info "build msi package $version"
 # delete previous build
-Remove-Item ".\mondoo_${arch}.exe" -ErrorAction Ignore
+Remove-Item ".\mondoo_${arch}.msi" -ErrorAction Ignore
 cd msi
 # delete previous intermediate files
 Remove-Item .\Product.wixobj -ErrorAction Ignore
@@ -31,12 +31,12 @@ info "run candle (standard)"
 
 info "run light (standard)"
 
-& 'C:\Program Files (x86)\WiX Toolset v3.14\bin\light' -nologo -dcl:high -cultures:en-us -loc en-us.wxl -ext WixUIExtension -ext WixUtilExtension product.wixobj -o "mondoo_${arch}.exe"
+& 'C:\Program Files (x86)\WiX Toolset v3.14\bin\light' -nologo -dcl:high -cultures:en-us -loc en-us.wxl -ext WixUIExtension -ext WixUtilExtension product.wixobj -o "mondoo_${arch}.msi"
 
 # delete previous intermediate files
 Remove-Item .\Product.wixobj -ErrorAction Ignore
 Remove-Item .\mondoo.wixpdb -ErrorAction Ignore
 cd ..
 
-Move-Item ".\msi\mondoo_${arch}.exe" .
+Move-Item ".\msi\mondoo_${arch}.msi" .
 

--- a/packages/msi/package.ps1
+++ b/packages/msi/package.ps1
@@ -19,7 +19,7 @@ function info($msg) {  Write-Host $msg -f white }
 
 info "build msi package $version"
 # delete previous build
-Remove-Item .\mondoo.msi -ErrorAction Ignore
+Remove-Item .\mondoo_"$platform".msi -ErrorAction Ignore
 cd msi
 # delete previous intermediate files
 Remove-Item .\Product.wixobj -ErrorAction Ignore
@@ -30,12 +30,12 @@ info "run candle (standard)"
 & 'C:\Program Files (x86)\WiX Toolset v3.14\bin\candle' -nologo  -dMondooSKU="standard" -darch="$platform" -dProductVersion="$version" -ext WixUtilExtension Product.wxs
 
 info "run light (standard)"
-& 'C:\Program Files (x86)\WiX Toolset v3.14\bin\light' -nologo -dcl:high -cultures:en-us -loc en-us.wxl -ext WixUIExtension -ext WixUtilExtension product.wixobj -o mondoo.msi
+& 'C:\Program Files (x86)\WiX Toolset v3.14\bin\light' -nologo -dcl:high -cultures:en-us -loc en-us.wxl -ext WixUIExtension -ext WixUtilExtension product.wixobj -o mondoo_"$platform".msi
 
 # delete previous intermediate files
 Remove-Item .\Product.wixobj -ErrorAction Ignore
 Remove-Item .\mondoo.wixpdb -ErrorAction Ignore
 cd ..
 
-Move-Item .\msi\mondoo.msi .
+Move-Item .\msi\mondoo_"$platform".msi .
 

--- a/packages/msi/package.ps1
+++ b/packages/msi/package.ps1
@@ -27,7 +27,7 @@ Remove-Item .\mondoo.wixpdb -ErrorAction Ignore
 # build package
 dir 'C:\Program Files (x86)\'
 info "run candle (standard)"
-& 'C:\Program Files (x86)\WiX Toolset v3.14\bin\candle' -nologo -arch "$platform" -dProductVersion="$version" -ext WixUtilExtension Product.wxs
+& 'C:\Program Files (x86)\WiX Toolset v3.14\bin\candle' -nologo  -dMondooSKU="standard" -darch="$platform" -dProductVersion="$version" -ext WixUtilExtension Product.wxs
 
 info "run light (standard)"
 & 'C:\Program Files (x86)\WiX Toolset v3.14\bin\light' -nologo -dcl:high -cultures:en-us -loc en-us.wxl -ext WixUIExtension -ext WixUtilExtension product.wixobj -o mondoo.msi
@@ -38,3 +38,4 @@ Remove-Item .\mondoo.wixpdb -ErrorAction Ignore
 cd ..
 
 Move-Item .\msi\mondoo.msi .
+

--- a/packages/msi/package.ps1
+++ b/packages/msi/package.ps1
@@ -3,13 +3,10 @@
 
 # use: ./package.ps1 -version 0.32.0
 param (
-    [string]$version = 'x.xx.x'
-)
-param (
+    [string]$version = 'x.xx.x',
     [string]$arch = 'amd64|arm64'
 )
 
-$platform = $arch -eq "amd64" ? "x64" : $arch
 
 function info($msg) {  Write-Host $msg -f white }
 
@@ -29,7 +26,7 @@ Remove-Item .\mondoo.wixpdb -ErrorAction Ignore
 # build package
 dir 'C:\Program Files (x86)\'
 info "run candle (standard)"
-& 'C:\Program Files (x86)\WiX Toolset v3.14\bin\candle' -nologo -arch "$platform" -dProductVersion="$version" -ext WixUtilExtension Product.wxs
+& 'C:\Program Files (x86)\WiX Toolset v3.14\bin\candle' -nologo -arch "$arch" -dProductVersion="$version" -ext WixUtilExtension Product.wxs
 
 info "run light (standard)"
 & 'C:\Program Files (x86)\WiX Toolset v3.14\bin\light' -nologo -dcl:high -cultures:en-us -loc en-us.wxl -ext WixUIExtension -ext WixUtilExtension product.wixobj -o mondoo.msi

--- a/packages/msi/package.ps1
+++ b/packages/msi/package.ps1
@@ -19,7 +19,7 @@ function info($msg) {  Write-Host $msg -f white }
 
 info "build msi package $version"
 # delete previous build
-Remove-Item ".\mondoo_${arch}.msi" -ErrorAction Ignore
+Remove-Item ".\mondoo_${arch}.exe" -ErrorAction Ignore
 cd msi
 # delete previous intermediate files
 Remove-Item .\Product.wixobj -ErrorAction Ignore
@@ -31,12 +31,12 @@ info "run candle (standard)"
 
 info "run light (standard)"
 
-& 'C:\Program Files (x86)\WiX Toolset v3.14\bin\light' -nologo -dcl:high -cultures:en-us -loc en-us.wxl -ext WixUIExtension -ext WixUtilExtension product.wixobj -o "mondoo_${arch}.msi"
+& 'C:\Program Files (x86)\WiX Toolset v3.14\bin\light' -nologo -dcl:high -cultures:en-us -loc en-us.wxl -ext WixUIExtension -ext WixUtilExtension product.wixobj -o "mondoo_${arch}.exe"
 
 # delete previous intermediate files
 Remove-Item .\Product.wixobj -ErrorAction Ignore
 Remove-Item .\mondoo.wixpdb -ErrorAction Ignore
 cd ..
 
-Move-Item ".\msi\mondoo_${arch}.msi" .
+Move-Item ".\msi\mondoo_${arch}.exe" .
 

--- a/packages/msi/package.ps1
+++ b/packages/msi/package.ps1
@@ -7,6 +7,7 @@ param (
     [string]$arch = 'amd64|arm64'
 )
 
+$platform = $arch -eq "amd64" ? "x64" : $arch
 
 function info($msg) {  Write-Host $msg -f white }
 
@@ -26,7 +27,7 @@ Remove-Item .\mondoo.wixpdb -ErrorAction Ignore
 # build package
 dir 'C:\Program Files (x86)\'
 info "run candle (standard)"
-& 'C:\Program Files (x86)\WiX Toolset v3.14\bin\candle' -nologo -arch "$arch" -dProductVersion="$version" -ext WixUtilExtension Product.wxs
+& 'C:\Program Files (x86)\WiX Toolset v3.14\bin\candle' -nologo -arch "$platform" -dProductVersion="$version" -ext WixUtilExtension Product.wxs
 
 info "run light (standard)"
 & 'C:\Program Files (x86)\WiX Toolset v3.14\bin\light' -nologo -dcl:high -cultures:en-us -loc en-us.wxl -ext WixUIExtension -ext WixUtilExtension product.wixobj -o mondoo.msi

--- a/packages/msi/package.ps1
+++ b/packages/msi/package.ps1
@@ -6,7 +6,6 @@ param (
     [string]$version = 'x.xx.x',
     [string]$arch = 'amd64|arm64'
 )
-Set-PSDebug -Trace 1
 
 $platform = $arch -eq "amd64" ? "x64" : $arch
 
@@ -20,7 +19,7 @@ function info($msg) {  Write-Host $msg -f white }
 
 info "build msi package $version"
 # delete previous build
-Remove-Item ".\mondoo_${platform}.msi" -ErrorAction Ignore
+Remove-Item ".\mondoo_${arch}.msi" -ErrorAction Ignore
 cd msi
 # delete previous intermediate files
 Remove-Item .\Product.wixobj -ErrorAction Ignore
@@ -32,12 +31,12 @@ info "run candle (standard)"
 
 info "run light (standard)"
 
-& 'C:\Program Files (x86)\WiX Toolset v3.14\bin\light' -nologo -dcl:high -cultures:en-us -loc en-us.wxl -ext WixUIExtension -ext WixUtilExtension product.wixobj -o "mondoo_${platform}.msi"
+& 'C:\Program Files (x86)\WiX Toolset v3.14\bin\light' -nologo -dcl:high -cultures:en-us -loc en-us.wxl -ext WixUIExtension -ext WixUtilExtension product.wixobj -o "mondoo_${arch}.msi"
 
 # delete previous intermediate files
 Remove-Item .\Product.wixobj -ErrorAction Ignore
 Remove-Item .\mondoo.wixpdb -ErrorAction Ignore
 cd ..
 
-Move-Item ".\msi\mondoo_${platform}.msi" .
+Move-Item ".\msi\mondoo_${arch}.msi" .
 

--- a/packages/msi/package.ps1
+++ b/packages/msi/package.ps1
@@ -19,7 +19,7 @@ function info($msg) {  Write-Host $msg -f white }
 
 info "build msi package $version"
 # delete previous build
-Remove-Item .\mondoo_"$platform".msi -ErrorAction Ignore
+Remove-Item ".\mondoo_${platform}.msi" -ErrorAction Ignore
 cd msi
 # delete previous intermediate files
 Remove-Item .\Product.wixobj -ErrorAction Ignore
@@ -30,12 +30,12 @@ info "run candle (standard)"
 & 'C:\Program Files (x86)\WiX Toolset v3.14\bin\candle' -nologo  -dMondooSKU="standard" -darch="$platform" -dProductVersion="$version" -ext WixUtilExtension Product.wxs
 
 info "run light (standard)"
-& 'C:\Program Files (x86)\WiX Toolset v3.14\bin\light' -nologo -dcl:high -cultures:en-us -loc en-us.wxl -ext WixUIExtension -ext WixUtilExtension product.wixobj -o mondoo_"$platform".msi
+& 'C:\Program Files (x86)\WiX Toolset v3.14\bin\light' -nologo -dcl:high -cultures:en-us -loc en-us.wxl -ext WixUIExtension -ext WixUtilExtension product.wixobj -o "mondoo_${platform}.msi"
 
 # delete previous intermediate files
 Remove-Item .\Product.wixobj -ErrorAction Ignore
 Remove-Item .\mondoo.wixpdb -ErrorAction Ignore
 cd ..
 
-Move-Item .\msi\mondoo_"$platform".msi .
+Move-Item ".\msi\mondoo_${platform}.msi" .
 

--- a/packages/msi/package.ps1
+++ b/packages/msi/package.ps1
@@ -4,6 +4,8 @@
 # use: ./package.ps1 -version 0.32.0
 param (
     [string]$version = 'x.xx.x'
+)
+param (
     [string]$arch = 'amd64|arm64'
 )
 

--- a/packages/msi/package.ps1
+++ b/packages/msi/package.ps1
@@ -4,7 +4,10 @@
 # use: ./package.ps1 -version 0.32.0
 param (
     [string]$version = 'x.xx.x'
+    [string]$arch = 'amd64|arm64'
 )
+
+$platform = $arch -eq "amd64" ? "x64" : $arch
 
 function info($msg) {  Write-Host $msg -f white }
 
@@ -24,7 +27,7 @@ Remove-Item .\mondoo.wixpdb -ErrorAction Ignore
 # build package
 dir 'C:\Program Files (x86)\'
 info "run candle (standard)"
-& 'C:\Program Files (x86)\WiX Toolset v3.14\bin\candle' -nologo -arch x64 -dMondooSKU="standard" -dProductVersion="$version" -ext WixUtilExtension Product.wxs
+& 'C:\Program Files (x86)\WiX Toolset v3.14\bin\candle' -nologo -arch "$platform" -dProductVersion="$version" -ext WixUtilExtension Product.wxs
 
 info "run light (standard)"
 & 'C:\Program Files (x86)\WiX Toolset v3.14\bin\light' -nologo -dcl:high -cultures:en-us -loc en-us.wxl -ext WixUIExtension -ext WixUtilExtension product.wixobj -o mondoo.msi


### PR DESCRIPTION
- remove hardcoded amd64 string everywhere
- parametrize builds to run for both amd64 and arm64

- [x] Successfully tested against local windows 10 arm64 VM

## Caveats
- installer filenames have changed from `mondoo.msi` to `mondoo_<arch>`.msi, e.g. `mondoo_arm64.msi`
- we should probably update the documentation at https://console.mondoo.com/space/integrations/add/mondoo/windows