### PR TITLE
Fix message details in slack posts

### DIFF
--- a/.github/workflows/check_gpg_key_not_expired.yml
+++ b/.github/workflows/check_gpg_key_not_expired.yml
@@ -32,7 +32,7 @@ jobs:
                       "fields": [
                         {
                           "type": "mrkdwn",
-                          "text": "<${{ github.event.workflow_run.html_url }}|${{ github.event.workflow_run.name }}>"
+                          "text": "<${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}|${{ github.workflow }}>"
                         },
                         {
                           "type": "mrkdwn",
@@ -83,7 +83,7 @@ jobs:
                       "fields": [
                         {
                           "type": "mrkdwn",
-                          "text": "<${{ github.event.workflow_run.html_url }}|${{ github.event.workflow_run.name }}>"
+                          "text": "<${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}|${{ github.workflow }}>"
                         },
                         {
                           "type": "mrkdwn",

--- a/.github/workflows/test_install_sh.yml
+++ b/.github/workflows/test_install_sh.yml
@@ -51,7 +51,7 @@ jobs:
                       "fields": [
                         {
                           "type": "mrkdwn",
-                          "text": "<${{ github.event.workflow_run.html_url }}|${{ github.event.workflow_run.name }}>"
+                          "text": "<${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}|${{ github.workflow }}>"
                         },
                         {
                           "type": "mrkdwn",
@@ -100,7 +100,7 @@ jobs:
                       "fields": [
                         {
                           "type": "mrkdwn",
-                          "text": "<${{ github.event.workflow_run.html_url }}|${{ github.event.workflow_run.name }}>"
+                          "text": "<${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}|${{ github.workflow }}>"
                         },
                         {
                           "type": "mrkdwn",


### PR DESCRIPTION
Slack posts were had some missing data to referencing non-existent fields in the `github.event` object. 