### PR TITLE
Add mondoo package to install.ps1 matrix tests

### DIFF
--- a/.github/workflows/test-released-install-ps1.yaml
+++ b/.github/workflows/test-released-install-ps1.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: ["windows-latest"]
-        package: ["cnquery", "cnspec"]
+        package: ["cnquery", "cnspec", "mondoo"]
     steps:
       - uses: actions/checkout@v4
       - name: Version
@@ -38,7 +38,7 @@ jobs:
           Install-Mondoo -Product ${{ matrix.package }};
       - name: Verify the correct version is installed
         run: |
-          $version=& 'C:\Program Files\Mondoo\${{ matrix.package }}.exe' version
+          $version=& 'C:\Program Files\Mondoo\${{ replace(matrix.package, 'mondoo', 'cnspec') }}".exe' version
           $match=$version -like "*${{ steps.version.outputs.version }}*"
           if (-not $match) {
             exit 1


### PR DESCRIPTION
- Test installing the mondoo.msi package via install.ps1
- Test whether the `cnspec` utility is the expected version