### PR TITLE
Increase docker build timeout to 20 minutes

### DIFF
--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build_container:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     name: Build Docker
     steps:
       - name: Clone repository


### PR DESCRIPTION
temp increase job timeout to 20 minutes as it consistently fails with the current limit of 10 minutes.