### PR TITLE
Trigger macos package build only on 'published' event

### DIFF
--- a/.github/workflows/pkg_macos.yaml
+++ b/.github/workflows/pkg_macos.yaml
@@ -17,7 +17,7 @@ on:
         default: false
         type: boolean
   release:
-    types: [released]
+    types: [published]
 
 jobs:
   pkg:


### PR DESCRIPTION
Currently macos package will trigger on 'released' event, which also includes draft releases.
Change to 'published' to be in sync with all other action triggers