### PR TITLE
[FEATURE] Use `switch` instead of boolean in powershell scan script

### DIFF
--- a/mdm-scripts/windows/scan.ps1
+++ b/mdm-scripts/windows/scan.ps1
@@ -38,7 +38,7 @@
 Param(
       [string]   $Product = 'cnspec',
       [string]   $RegistrationToken = '',
-      [bool]     $ForceRegistration = $false,
+      [switch]   $ForceRegistration = $false,
       [string]   $Proxy = '',
       [string]   $ExecutionPath = '',
       [string]   $DownloadPath = '',


### PR DESCRIPTION
If the script is rolled out via GPO and powershell.exe is invoked, arguments such as “$true” are interpreted as a string and therefore rejected. It would be better if we used the switch type. Simply specifying the parameter sets the value to $true

```powershell
scan.ps1 : Cannot process argument transformation on
parameter 'ForceRegistration'. Cannot convert value "System.String" to type "System.Boolean". Boolean parameters
accept only Boolean values and numbers, such as $True, $False, 1 or 0.
    + CategoryInfo          : InvalidData: (:) [scan.ps1], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : ParameterArgumentTransformationError,scan.ps1
```