### PR TITLE
🐛 Wait a bit longer before homebrew trigger

### DIFF
--- a/.github/workflows/pkg_macos.yaml
+++ b/.github/workflows/pkg_macos.yaml
@@ -157,8 +157,8 @@ jobs:
             "reindex-path": "mondoo/${{ env.VERSION }}",
             "bucket": "releases-us.mondoo.io"
             }'
-      - name: Wait a minute...
-        run: sleep 60
+      - name: Wait a bit...
+        run: sleep 120
       - name: Trigger Homebrew Generation
         uses: peter-evans/repository-dispatch@v3
         with:


### PR DESCRIPTION
From time to time, the cask update does not pick up the correct version and we need to re-run homebrew.

Perhaps this will fix it.