### PR TITLE
🧹 Unify inputs

### DIFF
--- a/.github/workflows/test-released-archlinux.yaml
+++ b/.github/workflows/test-released-archlinux.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Version
         id: version
         run: |
-          V=${{ github.event.inputs.version }}
+          V=${{ inputs.version }}
           VERSION=$(echo $V | sed 's/^v//')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Install cnquery with MakePKG on Arch Linux
@@ -45,7 +45,7 @@ jobs:
       - name: Version
         id: version
         run: |
-          V=${{ github.event.inputs.version }}
+          V=${{ inputs.version }}
           VERSION=$(echo $V | sed 's/^v//')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Install cnspec with Yay on Arch Linux

--- a/.github/workflows/test-released-brew.yaml
+++ b/.github/workflows/test-released-brew.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Version
         id: version
         run: |
-          V=${{ github.event.inputs.version }}
+          V=${{ inputs.version }}
           VERSION=$(echo $V | sed 's/^v//')
           echo "package_version=${VERSION}" >> $GITHUB_OUTPUT
 
@@ -62,7 +62,7 @@ jobs:
       - name: Version
         id: version
         run: |
-          V=${{ github.event.inputs.version }}
+          V=${{ inputs.version }}
           VERSION=$(echo $V | sed 's/^v//')
           echo "package_version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Executing cnspec from Mondoo package....

--- a/.github/workflows/test-released-docker.yaml
+++ b/.github/workflows/test-released-docker.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Version
         id: version
         run: |
-          V=${{ github.event.inputs.version }}
+          V=${{ inputs.version }}
           VERSION=$(echo $V | sed 's/^v//')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Testing mondoo/cnquery:${{ matrix.tag }}....
@@ -46,7 +46,7 @@ jobs:
       - name: Version
         id: version
         run: |
-          V=${{ github.event.inputs.version }}
+          V=${{ inputs.version }}
           VERSION=$(echo $V | sed 's/^v//')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Testing mondoo/cnspec:${{ matrix.tag }}....
@@ -66,7 +66,7 @@ jobs:
       - name: Version
         id: version
         run: |
-          V=${{ github.event.inputs.version }}
+          V=${{ inputs.version }}
           VERSION=$(echo $V | sed 's/^v//')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Testing mondoo/client:${{ matrix.tag }}....

--- a/.github/workflows/test-released-install-ps1.yaml
+++ b/.github/workflows/test-released-install-ps1.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Version
         id: version
         run: |
-          $v='${{ github.event.inputs.version }}'
+          $v='${{ inputs.version }}'
           $version=$v.trim("v","V")
           echo "version=$version" >> $env:GITHUB_OUTPUT
       - name: Install.ps1/${{ matrix.package }} on ${{ matrix.os }}

--- a/.github/workflows/test-released-install-sh.yaml
+++ b/.github/workflows/test-released-install-sh.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Version
         id: version
         run: |
-          V=${{ github.event.inputs.version }}
+          V=${{ inputs.version }}
           VERSION=$(echo $V | sed 's/^v//')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Install.sh/${{ matrix.package }} on ${{ matrix.distro }}
@@ -68,7 +68,7 @@ jobs:
       - name: Version
         id: version
         run: |
-          V=${{ github.event.inputs.version }}
+          V=${{ inputs.version }}
           VERSION=$(echo $V | sed 's/^v//')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Install.sh/${{ matrix.package }} on ${{ matrix.distro }}
@@ -87,7 +87,7 @@ jobs:
       - name: Version
         id: version
         run: |
-          V=${{ github.event.inputs.version }}
+          V=${{ inputs.version }}
           VERSION=$(echo $V | sed 's/^v//')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Install.sh/${{ matrix.package }} on ${{ matrix.os }}

--- a/.github/workflows/test-released-osx-pkg.yaml
+++ b/.github/workflows/test-released-osx-pkg.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Version
         id: version
         run: |
-          V=${{ github.event.inputs.version }}
+          V=${{ inputs.version }}
           VERSION=$(echo $V | sed 's/^v//')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Download Package


### PR DESCRIPTION
According to this, the inputs are available via this context:

https://github.blog/changelog/2022-06-10-github-actions-inputs-unified-across-manual-and-reusable-workflows/

That should fix the missing version: https://github.com/mondoohq/installer/actions/runs/12886298973/job/35927778066#step:3:2