### PR TITLE
Evaluate latest releases for completeness

### DIFF
--- a/.github/workflows/test-releases.yaml
+++ b/.github/workflows/test-releases.yaml
@@ -1,8 +1,8 @@
 name: Releases.mondoo.com File Validation
 
 on:
-  schedule:
-    - cron: '*/15 * * * *'  # Run every 15 minutes
+  #schedule:
+  #  - cron: '*/15 * * * *'  # Run every 15 minutes
   workflow_dispatch:  # Allow manual triggers
 
 jobs:

--- a/.github/workflows/test-releases.yaml
+++ b/.github/workflows/test-releases.yaml
@@ -1,0 +1,102 @@
+name: Releases.mondoo.com File Validation
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'  # Run every 15 minutes
+  workflow_dispatch:  # Allow manual triggers
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install requests
+    
+    - name: Validate Mondoo releases
+      id: mondoo
+      continue-on-error: true
+      run: |
+        python test/releases/validate_release.py mondoo > mondoo_output.txt
+        echo "mondoo_status=$?" >> $GITHUB_ENV
+        cat mondoo_output.txt
+    
+    - name: Validate cnquery releases
+      id: cnquery
+      continue-on-error: true
+      run: |
+        python test/releases/validate_release.py cnquery > cnquery_output.txt
+        echo "cnquery_status=$?" >> $GITHUB_ENV
+        cat cnquery_output.txt
+    
+    - name: Validate cnspec releases
+      id: cnspec
+      continue-on-error: true
+      run: |
+        python test/releases/validate_release.py cnspec > cnspec_output.txt
+        echo "cnspec_status=$?" >> $GITHUB_ENV
+        cat cnspec_output.txt
+    
+    - name: Send Slack notification on failure
+      if: env.mondoo_status != '0' || env.cnquery_status != '0' || env.cnspec_status != '0'
+      uses: slackapi/slack-github-action@v1.24.0
+      with:
+        channel-id: 'C07QZDJFF89'  # Replace with your channel ID
+        payload: |
+          {
+            "text": "⚠️ Release File Validation Failures Detected",
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": "⚠️ Release File Validation Failures"
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "*Validation Results:*"
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "${{ env.mondoo_status != '0' && '*Mondoo:* ❌ Failed\n' || '*Mondoo:* ✅ Passed\n' }}${{ env.cnquery_status != '0' && '*cnquery:* ❌ Failed\n' || '*cnquery:* ✅ Passed\n' }}${{ env.cnspec_status != '0' && '*cnspec:* ❌ Failed' || '*cnspec:* ✅ Passed' }}"
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "*Details:*\n```${{ env.mondoo_status != '0' && cat mondoo_output.txt || '' }}${{ env.cnquery_status != '0' && cat cnquery_output.txt || '' }}${{ env.cnspec_status != '0' && cat cnspec_output.txt || '' }}```"
+                }
+              },
+              {
+                "type": "context",
+                "elements": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View GitHub Action Run>"
+                  }
+                ]
+              }
+            ]
+          }
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    
+    - name: Final status check
+      if: env.mondoo_status != '0' || env.cnquery_status != '0' || env.cnspec_status != '0'
+      run: exit 1

--- a/test/releases/validate_release.py
+++ b/test/releases/validate_release.py
@@ -1,3 +1,6 @@
+# Copyright (c) Mondoo, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 import requests
 from typing import List, Dict, Set
 import sys

--- a/test/releases/validate_release.py
+++ b/test/releases/validate_release.py
@@ -1,0 +1,132 @@
+import requests
+from typing import List, Dict, Set
+import sys
+import argparse
+
+# Define expected files per endpoint
+EXPECTED_FILES = {
+    "mondoo": {
+        "darwin": ["darwin_universal.pkg"],
+        "linux": [
+            "linux_386.deb", "linux_386.rpm",
+            "linux_amd64.deb", "linux_amd64.rpm",
+            "linux_arm64.deb", "linux_arm64.rpm",
+            "linux_armv6.deb", "linux_armv6.rpm",
+            "linux_armv7.deb", "linux_armv7.rpm",
+            "linux_ppc64le.deb", "linux_ppc64le.rpm"
+        ],
+        "windows": ["windows_amd64.msi", "windows_arm64.msi"]
+    },
+    "cnquery": {
+        "darwin": ["darwin_universal.pkg"],
+        "linux": [
+            "linux_amd64.deb", "linux_amd64.rpm",
+            "linux_arm64.deb", "linux_arm64.rpm"
+        ],
+        "windows": ["windows_amd64.msi"]
+    },
+    "cnspec": {
+        "darwin": ["darwin_universal.pkg"],
+        "linux": [
+            "linux_amd64.deb", "linux_amd64.rpm",
+            "linux_arm64.deb", "linux_arm64.rpm"
+        ],
+        "windows": ["windows_amd64.msi"]
+    }
+}
+
+def human_size(size_in_bytes: int) -> str:
+    """Convert bytes to human readable string"""
+    for unit in ['B', 'KB', 'MB', 'GB']:
+        if size_in_bytes < 500.0:
+            return f"{size_in_bytes:3.1f}{unit}"
+        size_in_bytes /= 1024.0
+    return f"{size_in_bytes:.1f}GB"
+
+def validate_release_files(url: str, expected_files: Dict[str, List[str]], min_size: int = 500) -> List[str]:
+    """
+    Validates that all expected file types are present in a release.
+    
+    Args:
+        url: The URL of the release JSON endpoint
+        expected_files: Dictionary of platform-specific expected file suffixes
+        min_size: Minimum required file size
+    
+    Returns:
+        List of error messages, empty if validation successful
+    """
+    try:
+        response = requests.get(url)
+        response.raise_for_status()
+        data = response.json()
+        
+        errors = []
+        found_files = {}  # Store filename and size
+        version = data.get('version', '')
+        
+        print(f"\nValidating version: {version}")
+        print(f"{'File':<30} {'Status':<10} {'Size':<10}")
+        print("-" * 50)
+        
+        # First, collect all files from the release
+        for file in data.get('files', []):
+            filename = file.get('filename', '')
+            size = file.get('size', 0)
+            
+            if 'checksums' in filename.lower():
+                continue
+                
+            # Extract the file suffix
+            for platform, suffixes in expected_files.items():
+                for suffix in suffixes:
+                    if filename.endswith(f"{version}_{suffix}"):
+                        found_files[f"{platform}_{suffix}"] = size
+        
+        # Check each expected file
+        for platform, suffixes in expected_files.items():
+            for suffix in suffixes:
+                expected = f"{platform}_{suffix}"
+                if expected in found_files:
+                    size = found_files[expected]
+                    status = "FOUND" if size >= min_size else "SMALL"
+                    if size < min_size:
+                        errors.append(f"File size too small ({size} bytes): {suffix}")
+                    print(f"{suffix:<30} {status:<10} {human_size(size):<10}")
+                else:
+                    errors.append(f"Missing expected file: {suffix}")
+                    print(f"{suffix:<30} {'MISSING':<10} {'N/A':<10}")
+        
+        if errors:
+            print("\nErrors detected:")
+            for error in errors:
+                print(f"- {error}")
+        else:
+            print("\nAll files validated successfully")
+            
+        return errors
+        
+    except requests.exceptions.RequestException as e:
+        return [f"Failed to fetch release data: {str(e)}"]
+    except ValueError as e:
+        return [f"Failed to parse JSON data: {str(e)}"]
+
+def main():
+    parser = argparse.ArgumentParser(description='Validate release files for Mondoo products')
+    parser.add_argument('product', choices=['mondoo', 'cnquery', 'cnspec'], help='Product to validate')
+    args = parser.parse_args()
+    
+    endpoints = {
+        "mondoo": "https://releases.mondoo.com/mondoo/latest.json",
+        "cnquery": "https://releases.mondoo.com/cnquery/latest.json",
+        "cnspec": "https://releases.mondoo.com/cnspec/latest.json"
+    }
+    
+    url = endpoints[args.product]
+    print(f"\nValidating {args.product} release at {url}")
+    errors = validate_release_files(url, EXPECTED_FILES[args.product])
+    
+    if errors:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
It is unacceptable for a release to ever miss files.  In our complex pipeline its possible  that one of the files we expect to be released doesn't, for one reason or another, actually make it up to releases.mondoo.com.  This action tests for the presence of all expected files for mondoo, cnspec, and cnquery and reports to our release coordination slack channel if something if found missing.

Because the files all need to be present a period later than the actual release, because of time to build and release as well as CDN cache effect, we run this continuously as a cron every 15m.