### PR TITLE
Check and slowdown for SHAs to update

### DIFF
--- a/packages/chocolatey/cnquery-generate.sh
+++ b/packages/chocolatey/cnquery-generate.sh
@@ -42,6 +42,16 @@ NUSPEC
 
 
 CHECKSUM=`curl -s https://install.mondoo.com/package/cnquery/windows/amd64/zip/${VERSION}/sha256`
+if [ $CHECKSUM = "internal server error" ]; then
+  echo "--- WARNING: Install service has not yet been updated with the SHAs.  WAITING 3 MINUTES ---"
+  sleep 300
+fi
+
+CHECKSUM=`curl -s https://install.mondoo.com/package/cnquery/windows/amd64/zip/${VERSION}/sha256`
+if [ $CHECKSUM = "internal server error" ]; then
+  echo "--- FATAL ERROR: SHAs not available from https://install.mondoo.com/package/cnquery/windows/amd64/zip/${VERSION}/sha256"
+  exit 1
+fi
 
 echo "Generating Install Script"
 mkdir tools

--- a/packages/chocolatey/cnspec-generate.sh
+++ b/packages/chocolatey/cnspec-generate.sh
@@ -47,6 +47,16 @@ NUSPEC
 
 
 CHECKSUM=`curl -s https://install.mondoo.com/package/cnspec/windows/amd64/zip/${VERSION}/sha256`
+if [ $CHECKSUM = "internal server error" ]; then
+  echo "--- WARNING: Install service has not yet been updated with the SHAs.  WAITING 3 MINUTES ---"
+  sleep 300
+fi
+
+CHECKSUM=`curl -s https://install.mondoo.com/package/cnspec/windows/amd64/zip/${VERSION}/sha256`
+if [ $CHECKSUM = "internal server error" ]; then
+  echo "--- FATAL ERROR: SHAs not available from https://install.mondoo.com/package/cnspec/windows/amd64/zip/${VERSION}/sha256"
+  exit 1
+fi
 
 echo "Generating Install Script"
 mkdir tools


### PR DESCRIPTION
After recent improvements we've encountered a problem whereby Choco packages are generating too quickly after release.  The build scripts rely on the installer service to provide the SHA checksums but releases hasn't been updated yet so we get an error instead.  

The solution here is to add a 300s sleep if the SHAs aren't available and if after that they are still unsable to exit with an error, rather than silently fail.