### PR TITLE
fix(ci): Move chocolatey trigger after reindex

### DIFF
--- a/.github/workflows/pkg_published_trigger_build_release.yaml
+++ b/.github/workflows/pkg_published_trigger_build_release.yaml
@@ -44,13 +44,6 @@ jobs:
       version: ${{ needs.parse-inputs.outputs.version }}
       skip-publish: ${{ needs.parse-inputs.outputs.skip-publish == 'true' }}
       bucket: ${{ needs.parse-inputs.outputs.bucket }}
-  build-chocolatey:
-    uses: ./.github/workflows/pkg_chocolatey.yaml
-    secrets: inherit
-    needs: [ parse-inputs ]
-    with:
-      version: ${{ needs.parse-inputs.outputs.version }}
-      skip-publish: ${{ needs.parse-inputs.outputs.skip-publish == 'true' }}
   build-mondoo-pkgs:
     uses: ./.github/workflows/release_mondoo_pkgs.yaml
     secrets: inherit
@@ -61,7 +54,7 @@ jobs:
       bucket: ${{ needs.parse-inputs.outputs.bucket }}
   reindex:
     runs-on: ubuntu-latest
-    needs: [ parse-inputs, build-msi, build-chocolatey, build-mondoo-pkgs ]
+    needs: [ parse-inputs, build-msi, build-mondoo-pkgs ]
     steps:
     # fetch a token for the mondoo-mergebot app
     - name: Generate token
@@ -148,6 +141,13 @@ jobs:
       version: ${{ needs.parse-inputs.outputs.version }}
       skip-publish: ${{ needs.parse-inputs.outputs.skip-publish == 'true' }}
       bucket: ${{ needs.parse-inputs.outputs.bucket }}
+  build-chocolatey:
+    uses: ./.github/workflows/pkg_chocolatey.yaml
+    secrets: inherit
+    needs: [ parse-inputs, reindex ]
+    with:
+      version: ${{ needs.parse-inputs.outputs.version }}
+      skip-publish: ${{ needs.parse-inputs.outputs.skip-publish == 'true' }}
   build-container:
     needs: [ parse-inputs, reindex ]
     secrets: inherit

--- a/.github/workflows/pkg_published_trigger_build_release.yaml
+++ b/.github/workflows/pkg_published_trigger_build_release.yaml
@@ -150,4 +150,5 @@ jobs:
       bucket: ${{ needs.parse-inputs.outputs.bucket }}
   build-container:
     needs: [ parse-inputs, reindex ]
+    secrets: inherit
     uses: ./.github/workflows/build_container.yml


### PR DESCRIPTION
- Chocolatey has a dependency on cnspec & cnquery being published to install.mondoo.com