### PR TITLE
Update Cert Sync method due to DigiCert change

### DIFF
--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -126,7 +126,7 @@ jobs:
           smksp_registrar.exe list
           smctl.exe keypair ls
           C:\Windows\System32\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user
-          smksp_cert_sync.exe
+          smctl.exe windows certsync
 
       - name: Build and Sign MSI
         env:


### PR DESCRIPTION
Recent announced changes by DigiCert have broken the msksp_cert_sync.exe method that was previously recommended, their support team reports that using 'smctl windows certsync instead' should fix it.