### PR TITLE
Advise Users intending to Re-Register an Agent

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -557,6 +557,7 @@ configure_token() {
   if [ "$MONDOO_IS_REGISTERED" = true ]; then
     purple_bold "\n* ${MONDOO_PRODUCT_NAME} is already logged-in. Skipping login"
     purple_bold "(you can manually run '${MONDOO_BINARY} login' to re-authenticate)."
+    purple_bold "To re-register with a new space, please remove your Mondoo config file first."
     config_path="$HOME/.config/mondoo"
     if [ "$MONDOO_SERVICE" = "enable" ] && [ "$OS" = "macOS" ]; then
       sudo_cmd cp "$config_path/mondoo.yml" /Library/Mondoo/etc/mondoo.yml


### PR DESCRIPTION
A user may want to re-register a client with a new Mondoo org/space during install but this requires the Mondoo config be deleted first, which would likely create more problems than it solves.  As a middle-ground we add a note to the output that re-registrations should happen after deleting the config file manually.