### PR TITLE
Pinning gh-action-release to 2.2.2 as 2.2.3 introduced stack trace on…

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -62,7 +62,7 @@ jobs:
           private-key: ${{ secrets.MONDOO_MERGEBOT_APP_PRIVATE_KEY }}
       - name: Release
         id: release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.2.2
         with:
           tag_name: ${{ steps.version.outputs.version }}
           generate_release_notes: true

--- a/.github/workflows/release_mondoo_pkgs.yaml
+++ b/.github/workflows/release_mondoo_pkgs.yaml
@@ -91,7 +91,7 @@ jobs:
           $SKIP gsutil cp -r helper/packages/* gs://${{ inputs.bucket }}/mondoo/${{ inputs.version }}/
       - name: Upload files to GitHub Release Page
         if: ${{ !inputs.skip-publish }}
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.2.2
         with:
           tag_name: v${{ inputs.version }}
           files: helper/packages/*


### PR DESCRIPTION
Looks like this action has introduce a bug 'softprops/action-gh-release@v2' based on https://github.com/softprops/action-gh-release/commit/d5382d3e6f2fa7bd53cb749d33091853d4985daf and https://github.com/softprops/action-gh-release/issues/628

So pinning to previous version