### PR TITLE
:broom: Failsafe for Suse 15

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -473,7 +473,7 @@ configure_suse_installer() {
       curl -A "${UserAgent}" --retry 3 --retry-delay 10 -sSL https://releases.mondoo.com/rpm/mondoo.repo | sudo_cmd tee /etc/zypp/repos.d/mondoo.repo
       # zypper does not recognize the gpg key reference from mondoo.repo properly, therefore we need to add this here manually
       sudo_cmd rpm --import https://releases.mondoo.com/rpm/pubkey.gpg
-      sudo zypper refresh
+      sudo_cmd zypper refresh
 
 
       purple_bold "\n* Installing ${MONDOO_PRODUCT_NAME}"

--- a/install.sh
+++ b/install.sh
@@ -473,6 +473,8 @@ configure_suse_installer() {
       curl -A "${UserAgent}" --retry 3 --retry-delay 10 -sSL https://releases.mondoo.com/rpm/mondoo.repo | sudo_cmd tee /etc/zypp/repos.d/mondoo.repo
       # zypper does not recognize the gpg key reference from mondoo.repo properly, therefore we need to add this here manually
       sudo_cmd rpm --import https://releases.mondoo.com/rpm/pubkey.gpg
+      sudo zypper refresh
+
 
       purple_bold "\n* Installing ${MONDOO_PRODUCT_NAME}"
       sudo_cmd zypper -n install ${MONDOO_PKG_NAME}


### PR DESCRIPTION
When using the installer.sh on the CIS SUSE 15 image it fails because of this:
```
Problem retrieving files from 'SLE-Module-Basesystem15-SP6-Updates'.
Credentials are invalid. For details see "/var/log/cloudregister". Re-register the system with "registercloudguest --force-new"
```

After manually registering simply re-running the `installer.sh` script runs into an error:
```
ip-10-0-101-139:/home/ec2-user # bash -c "$(curl -sSL https://install.mondoo.com/sh)"
mondoo package for cnquery and cnspec Installer

                        .-.
                        : :
,-.,-.,-. .--. ,-.,-. .-' : .--.  .--. ™
: ,. ,. :' .; :: ,. :' .; :' .; :' .; :
:_;:_;:_;`.__.':_;:_;`.__.'`.__.'`.__.


Welcome to the mondoo package for cnquery and cnspec installer. We
will auto-detect your operating system to determine the best installation
method. If you experience any issues, please reach us at:

  * Mondoo Community GitHub Discussions:
    https://github.com/orgs/mondoohq/discussions

This installer is licensed under the Apache License, Version 2.0

  * GitHub:
  https://github.com/mondoohq/installer


* Installing mondoo package for cnquery and cnspec via apt

* Configuring ZYPPER sources for Mondoo at /etc/zypp/repos.d/mondoo.repo
[mondoo]
name=Mondoo Repository
baseurl=https://releases.mondoo.com/rpm/$basearch
enabled=1
gpgcheck=1
gpgkey=https://releases.mondoo.com/rpm/pubkey.gpg
metadata_expire=21600

* Installing mondoo package for cnquery and cnspec
Refreshing service 'Basesystem_Module_x86_64'.
Refreshing service 'Confidential_Computing_Module_x86_64'.
Refreshing service 'Containers_Module_x86_64'.
Refreshing service 'Desktop_Applications_Module_x86_64'.
Refreshing service 'Development_Tools_Module_x86_64'.
Refreshing service 'Public_Cloud_Module_x86_64'.
Refreshing service 'Python_3_Module_x86_64'.
Refreshing service 'SUSE_Linux_Enterprise_Server_x86_64'.
Refreshing service 'Server_Applications_Module_x86_64'.
Refreshing service 'Web_and_Scripting_Module_x86_64'.
Loading repository data...
Reading installed packages...
Resolving package dependencies...

The following 3 NEW packages are going to be installed:
  cnquery cnspec mondoo

The following 3 packages have no support information from their vendor:
  cnquery cnspec mondoo

3 new packages to install.

Package download size:
              |      39.5 MiB  overall package size
     5.9 KiB  |  -   39.5 MiB  already in cache

Package install size change:
              |     121.3 MiB  required by packages that will be installed
   121.3 MiB  |  -      0 B    released by packages that will be removed

Backend:  classic_rpmtrans
Continue? [y/n/v/...? shows all options] (y): y
In cache cnquery_11.57.2_linux_amd64.rpm                                                                                                                (1/3),  17.1 MiB
In cache cnspec_11.57.2_linux_amd64.rpm                                                                                                                 (2/3),  22.4 MiB
Retrieving: mondoo-11.57.2-1.noarch (Mondoo Repository)                                                                                                 (3/3),   5.9 KiB
Retrieving: mondoo_11.57.2_linux_amd64.rpm ...........................................................................................................................[done]

Warning: Digest verification failed for file 'mondoo_11.57.2_linux_amd64.rpm'
[/var/tmp/AP_0xOH3NVp/mondoo_11.57.2_linux_amd64.rpm]

  expected 451d0eb73d657631e1f036dfcdd639c401f4746b4717bead94c3882a4b8670e1
  but got  efcc1e24abede8f29f130f1c2f510172eb03d1621c5b608cbba7f02bf2105330
``` 

This can be fixed by refreshing zypper.
```
Backend:  classic_rpmtrans
Continue? [y/n/v/...? shows all options] (y): y
Retrieving: cnquery-11.58.0-1.x86_64 (Mondoo Repository)                                                                                                (1/3),  17.1 MiB
Retrieving: cnquery_11.58.0_linux_amd64.rpm .............................................................................................................[done (12.2 MiB/s)]
Retrieving: cnspec-11.58.0-1.x86_64 (Mondoo Repository)                                                                                                 (2/3),  22.4 MiB
Retrieving: cnspec_11.58.0_linux_amd64.rpm ..............................................................................................................[done (20.2 MiB/s)]
Retrieving: mondoo-11.58.0-1.noarch (Mondoo Repository)                                                                                                 (3/3),   5.9 KiB
Retrieving: mondoo_11.58.0_linux_amd64.rpm ...........................................................................................................................[done]

Checking for file conflicts: .........................................................................................................................................[done]
(1/3) Installing: cnquery-11.58.0-1.x86_64 ...........................................................................................................................[done]
 -> Prepare for cnspec installation
 -> Migrate cnspec configuration
! can't find any paths for providers, none are configured system-path=/opt/mondoo/providers
→ No migration needed.
(2/3) Installing: cnspec-11.58.0-1.x86_64 ............................................................................................................................[done]
(3/3) Installing: mondoo-11.58.0-1.noarch ............................................................................................................................[done]
mondoo package for cnquery and cnspec installation completed.

* No registration token provided, skipping Mondoo Platform authentication.

mondoo package for cnquery and cnspec is ready to go!
```

