### PR TITLE
Prevent garbage characters when running install on ubuntu

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -442,13 +442,13 @@ configure_debian_installer() {
       apt_update
 
       purple_bold "\n* Installing ${MONDOO_PRODUCT_NAME}"
-      sudo_cmd apt update -y && sudo_cmd apt install -y ${MONDOO_PKG_NAME}
+      sudo_cmd apt update -y && TERM=dumb sudo_cmd apt install -y ${MONDOO_PKG_NAME}
     }
 
     mondoo_update() {
       # Always update GPG Key & Apt Source for Freshness
       apt_update
-      sudo_cmd apt update -y && sudo_cmd apt --only-upgrade install -y ${MONDOO_PKG_NAME}
+      sudo_cmd apt update -y && TERM=dumb sudo_cmd apt --only-upgrade install -y ${MONDOO_PKG_NAME}
     }
 
   else


### PR DESCRIPTION
There seems to be some issue with the way termenv queries the terminal while doing an apat install that produces garbage characters.

For example, consider a install.sh
```
sudo apt install mondoo
```

```
bash install.sh
```

works fine.

```
cat install.sh | bash -s
```

produces garbage characters

This should fix https://github.com/mondoohq/installer/issues/500