### PR TITLE
Update configure_suse_installer in install.sh to correctly detect MONDOO_INSTALLER

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -467,7 +467,7 @@ configure_debian_installer() {
 
 configure_suse_installer() {
   if [ -x "$(command -v zypper)" ]; then
-    MONDOO_INSTALLER="apt"
+    MONDOO_INSTALLER="zypper"
     mondoo_install() {
       purple_bold "\n* Configuring ZYPPER sources for Mondoo at /etc/zypp/repos.d/mondoo.repo"
       curl -A "${UserAgent}" --retry 3 --retry-delay 10 -sSL https://releases.mondoo.com/rpm/mondoo.repo | sudo_cmd tee /etc/zypp/repos.d/mondoo.repo


### PR DESCRIPTION
The custom function configure_suse_installer sets the variable MONDOO_INSTALLER to apt instead of zypper. This PR changes the function so that it sets the variable to 'zypper' instead. This should not affect any behaviour, as the variable is only used to check whether a suitable installer can be identified:

```bash
if [ -z "${MONDOO_INSTALLER}" ]; then
  red "Cannot determine which installer to use. Exiting."
  exit 1
fi
```
https://github.com/mondoohq/installer/blob/5f0ce827a716a771946eb8e679b68b7243c26fbd/install.sh#L841C1-L844C3