### PR TITLE
Added go binary help validate the releases website

### DIFF
--- a/.github/workflows/test-releases.yaml
+++ b/.github/workflows/test-releases.yaml
@@ -11,6 +11,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Run release-site-checker to ensure the release site doesn't just list providers
+      id: html
+      continue-on-error: true
+      run: |
+        chmod +x ./test/releases/release-site-checker-linux
+        ./test/releases/release-site-checker-linux && echo "html_status=$?" >> $GITHUB_ENV || echo "html_status=$?" >> $GITHUB_ENV
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -35,7 +41,7 @@ jobs:
       run: |
         python test/releases/validate_release.py cnspec && echo "cnspec_status=$?" >> $GITHUB_ENV || echo "cnspec_status=$?" >> $GITHUB_ENV
     - name: Send Slack notification on failure
-      if: env.mondoo_status != '0' || env.cnquery_status != '0' || env.cnspec_status != '0'
+      if: env.mondoo_status != '0' || env.cnquery_status != '0' || env.cnspec_status != '0' || env.html_status != '0'
       uses: slackapi/slack-github-action@v2.0.0
       with:
         method: chat.postMessage
@@ -63,7 +69,7 @@ jobs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": "${{ env.mondoo_status != '0' && '*Mondoo:* ❌ Failed\n' || '*Mondoo:* ✅ Passed\n' }}${{ env.cnquery_status != '0' && '*cnquery:* ❌ Failed\n' || '*cnquery:* ✅ Passed\n' }}${{ env.cnspec_status != '0' && '*cnspec:* ❌ Failed' || '*cnspec:* ✅ Passed' }}"
+                  "text": "${{ env.mondoo_status != '0' && '*Mondoo:* ❌ Failed\n' || '*Mondoo:* ✅ Passed\n' }}${{ env.cnquery_status != '0' && '*cnquery:* ❌ Failed\n' || '*cnquery:* ✅ Passed\n' }}${{ env.cnspec_status != '0' && '*cnspec:* ❌ Failed' || '*cnspec:* ✅ Passed' }}${{ env.html_status != '0' && '*html:* ❌ Failed' || '*html:* ✅ Passed' }}"
                 }
               },
               {
@@ -79,5 +85,5 @@ jobs:
             ]
           }
     - name: Final status check
-      if: env.mondoo_status != '0' || env.cnquery_status != '0' || env.cnspec_status != '0'
+      if: env.mondoo_status != '0' || env.cnquery_status != '0' || env.cnspec_status != '0' || env.html_status != '0'
       run: exit 1

--- a/test/releases/README.md
+++ b/test/releases/README.md
@@ -1,0 +1,5 @@
+## 📁 Source
+
+The source code for this tool lives in the [`platform-engineering`](https://github.com/mondoohq/platform-engineering) repository.
+
+This repo contains the Go implementation, tests used to check the integrity of the Mondoo releases site.


### PR DESCRIPTION
We have a gap in our testing at the moment with regards to the `releases.mondoo.com` website.  Sometimes the reindex task truncates all the folders and only lists the providers folder.  As seen in this example

<img width="894" height="304" alt="image" src="https://github.com/user-attachments/assets/f39bd5e6-5e5b-44b4-bc5a-9bec1aaf03fc" />

The existing tests validate the json which is there and correct but not the html  so the help the user can't browse and download the required package