### PR TITLE
Switched to Azure Trusted Signing for signing our MSI's

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -35,6 +35,7 @@ AXu
 BAhe
 bdt
 BEAC
+BEBE
 BFKt
 Bhh
 BHQw
@@ -111,12 +112,15 @@ EDWc
 Ees
 EETOk
 eeuyk
+EFC
+EFFFA
 Eflsgg
 EFSLKJm
 EGAEKACYC
 EGAEKACYWIQRM
 EMo
 ENtx
+EOC
 epz
 EQAMAi
 EQeg

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -64,7 +64,7 @@ jobs:
       matrix:
         arch:
           - amd64
-#TODO - REENABLE          - arm64
+          - arm64
     runs-on: ubuntu-latest
     needs: setup
     steps:
@@ -97,7 +97,7 @@ jobs:
       matrix:
         arch:
           - amd64
- #TODO - REENABLE         - arm64
+          - arm64
     needs:
       - setup
       - dist-prepare
@@ -181,10 +181,58 @@ jobs:
         with:
           name: msi-${{ matrix.arch }}
           path: dist
-      - name: Verify digital signature is valid
+      - name: Verify Signed MSI Status
+        shell: powershell
         run: |
-          cd dist
-          Get-AuthenticodeSignature -FilePath .\\mondoo_${{ matrix.arch }}.msi
+          $msiFileName = "mondoo_${{ matrix.arch }}.msi"
+          $msiFilePath = Join-Path -Path (Get-Location) -ChildPath "dist\$msiFileName"
+
+          Write-Host "Attempting to verify digital signature for MSI: $msiFilePath"
+
+          # --- Pre-check: Ensure the file exists ---
+          if (-not (Test-Path $msiFilePath)) {
+              Write-Error "Error: MSI file not found at '$msiFilePath'. Cannot verify signature."
+              exit 1 # Fail the step if the file is missing
+          }
+
+          # --- Signature Verification ---
+          try {
+              $signature = Get-AuthenticodeSignature -FilePath $msiFilePath
+
+              Write-Host "Signature Status: $($signature.Status)"
+
+              if ($signature.Status -eq "Valid") {
+                  Write-Host "Success: The MSI has a valid signature."
+                  Write-Host "Signed by: $($signature.SignerCertificate.Subject)"
+                  Write-Host "Issued by: $($signature.SignerCertificate.Issuer)"
+                  Write-Host "Valid From: $($signature.SignerCertificate.NotBefore)"
+                  Write-Host "Valid To: $($signature.SignerCertificate.NotAfter)"
+              }
+              else {
+                  # For any status other than 'Valid', treat as a failure
+                  Write-Error "Error: MSI signature verification failed or is not valid. Status: $($signature.Status)"
+
+                  # Provide more context for common non-valid statuses
+                  if ($signature.Status -eq "NotSigned") {
+                      Write-Error "Reason: The MSI is not digitally signed."
+                  } elseif ($signature.Status -eq "HashMismatch") {
+                      Write-Error "Reason: The file has been tampered with since signing (hash mismatch)."
+                  } elseif ($signature.Status -eq "Untrusted") {
+                      Write-Error "Reason: The certificate chain could not be built to a trusted root authority."
+                      # Output details of the certificate if untrusted, for debugging
+                      Write-Host "Untrusted Certificate Subject: $($signature.SignerCertificate.Subject)"
+                      Write-Host "Untrusted Certificate Thumbprint: $($signature.SignerCertificate.Thumbprint)"
+                  } elseif ($signature.Status -eq "UnknownError") {
+                      Write-Error "Reason: An unknown error occurred during signature verification."
+                  }
+
+                  exit 1 # Fail the step
+              }
+          }
+          catch {
+              Write-Error "An unexpected error occurred during signature verification: $($_.Exception.Message)"
+              exit 1 # Fail the step
+          }
       - name: Install artifact
         run: |
           $TEMP_PATH = $env:TEMP

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -1,44 +1,54 @@
-name: 'PKG: Microsoft Software Installer (MSI)'
+name: "PKG: Microsoft Software Installer (MSI)"
 
 on:
   workflow_call:
     inputs:
       version:
-        description: 'Package Version'
+        description: "Package Version"
         required: true
-        default: '8.99.99'
-        type: 'string'
+        default: "8.99.99"
+        type: "string"
       skip-publish:
-        description: 'Skip publish?'
+        description: "Skip publish?"
         required: false
         default: false
         type: boolean
       bucket:
-        description: 'GCP Release Bucket Name'
+        description: "GCP Release Bucket Name"
         required: true
-        default: 'releases-us.mondoo.io'
+        default: "releases-us.mondoo.io"
         type: string
+      use-test-cert:
+        description: "Use test certificate profile (not publicly trusted)"
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       version:
-        description: 'Package Version'
+        description: "Package Version"
         required: true
-        default: '0.0.1'
-        type: 'string'
+        default: "0.0.1"
+        type: "string"
       skip-publish:
-        description: 'Skip publish?'
+        description: "Skip publish?"
         required: false
         default: false
         type: boolean
       bucket:
-        description: 'GCP Release Bucket Name'
+        description: "GCP Release Bucket Name"
         required: true
-        default: 'releases-us.mondoo.io'
+        default: "releases-us.mondoo.io"
         type: string
+      use-test-cert:
+        description: "Use test certificate profile (not publicly trusted)"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   setup:
-    name: 'Setup'
+    name: "Setup"
     runs-on: ubuntu-latest
     steps:
       - name: Ensure version of cnquery and cnspec are available
@@ -81,7 +91,7 @@ jobs:
           path: dist/${{ matrix.arch }}
 
   msi-build:
-    name: 'Packaging: Windows MSI'
+    name: "Packaging: Windows MSI"
     runs-on: windows-latest
     strategy:
       matrix:
@@ -101,34 +111,7 @@ jobs:
           name: dist-${{ matrix.arch }}
           path: dist/${{ matrix.arch }}
 
-      - name: Setup Certificate
-        shell: bash
-        run: |
-          echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
-
-      - name: Set signing variables
-        shell: bash
-        run: |
-          echo "SM_HOST=${{ secrets.SM_HOST }}" >> "$GITHUB_ENV"
-          echo "SM_API_KEY=${{ secrets.SM_API_KEY }}" >> "$GITHUB_ENV"
-          echo "SM_CLIENT_CERT_FILE=D:\\Certificate_pkcs12.p12" >> "$GITHUB_ENV"
-          echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_CLIENT_CERT_PASSWORD }}" >> "$GITHUB_ENV"
-          echo "SM_CODE_SIGNING_CERT_SHA1_HASH=${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}" >> "$GITHUB_ENV"
-          echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH
-          echo "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools" >> $GITHUB_PATH
-          echo "C:\Program Files\DigiCert\DigiCert One Signing Manager Tools" >> $GITHUB_PATH
-
-      - name: Setup SSM KSP on windows latest
-        shell: cmd
-        run: |
-          curl --retry 10 --retry-delay 60 -X GET  https://one.digicert.com/signingmanager/api-ui/v1/releases/smtools-windows-x64.msi/download -H "x-api-key:%SM_API_KEY%" -o smtools-windows-x64.msi
-          msiexec /i smtools-windows-x64.msi /quiet /qn
-          smksp_registrar.exe list
-          smctl.exe keypair ls
-          C:\Windows\System32\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user
-          smctl.exe windows certsync
-
-      - name: Build and Sign MSI
+      - name: Build MSI
         env:
           VERSION: ${{ inputs.version }}
         run: |
@@ -142,25 +125,36 @@ jobs:
           echo " - Packaging MSI..."
           Set-Location -Path '.\packages\msi\'
           ./package.ps1 -version $mondooVersion -arch ${{ matrix.arch }}
-          # sign msi package
-          echo " - Signing MSI..."
-          Set-Location -Path '.\..\..'
-          signtool.exe sign /debug /sha1 ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 .\packages\msi\mondoo_${{ matrix.arch }}.msi
-          Copy-Item '.\packages\msi\mondoo_${{ matrix.arch }}.msi' '.\dist\${{ matrix.arch }}'
-      - name: Dump Signing Log on Failure
-        if: failure()
-        run: |
-          echo "Dumping signing logs..."
-          gc $home\AppData\Local\Temp\signtool.log
-          echo "Dumping signing manager logs..."
-          gc $home\.signingmanager\logs\smctl.log
-          echo "Dumping signing manager KSP logs..."
-          gc $home\.signinmanager\logs\smksp.log
-          echo "Dumping signing manager KSP cert sync logs..."
-          gc $home\.signingmanager\logs\smksp_cert_sync.log
+
+      - name: Sign files with Trusted Signing
+        uses: azure/trusted-signing-action@v0
+        with:
+          azure-tenant-id: ${{ vars.TSIGN_AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.TSIGN_AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.TSIGN_AZURE_CLIENT_SECRET }}
+          endpoint: ${{ vars.TSIGN_AZURE_ENDPOINT }}
+          trusted-signing-account-name: ${{ vars.TSIGN_ACCOUNT_NAME }}
+          # Conditional logic for switching certificate-profile-name type
+          certificate-profile-name: ${{ github.event.inputs.use-test-cert == 'true' && vars.TSIGN_TEST_CERT_PROFILE_NAME || vars.TSIGN_CERT_PROFILE_NAME }}
+          files: |
+            .\packages\msi\mondoo_${{ matrix.arch }}.msi
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA384
+          exclude-environment-credential: false
+          exclude-workload-identity-credential: true
+          exclude-managed-identity-credential: true
+          exclude-shared-token-cache-credential: true
+          exclude-visual-studio-credential: true
+          exclude-visual-studio-code-credential: true
+          exclude-azure-cli-credential: true
+          exclude-azure-powershell-credential: true
+          exclude-azure-developer-cli-credential: true
+          exclude-interactive-browser-credential: true
 
       - name: Cleanup dist before upload
         run: |
+          Copy-Item '.\packages\msi\mondoo_${{ matrix.arch }}.msi' '.\dist\${{ matrix.arch }}'
           Remove-Item -Path .\dist\${{ matrix.arch }}\cnquery.exe -Force
           Remove-Item -Path .\dist\${{ matrix.arch }}\cnspec.exe -Force
 
@@ -176,7 +170,7 @@ jobs:
       matrix:
         arch:
           - amd64
-#          - arm64 # we currently don't have windows arm64 runners to test arm against
+    #          - arm64 # we currently don't have windows arm64 runners to test arm against
     needs:
       - setup
       - msi-build
@@ -234,7 +228,7 @@ jobs:
           & 'C:\Program Files\Mondoo\cnspec.exe' logout --config C:\ProgramData\Mondoo\mondoo.yml --force
 
   publish:
-    name: 'Publish: Releases'
+    name: "Publish: Releases"
     strategy:
       matrix:
         arch:

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -101,7 +101,7 @@ jobs:
   msi-build:
     name: "Packaging: Windows MSI"
     environment: prod
-    runs-on: windows-latest
+    runs-on: windows-2025
     strategy:
       matrix:
         arch:
@@ -189,7 +189,7 @@ jobs:
     needs:
       - setup
       - msi-build
-    runs-on: windows-latest
+    runs-on: windows-2025
     steps:
       - name: Download MSI Package
         uses: actions/download-artifact@v4

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -6,7 +6,7 @@ on:
       version:
         description: "Package Version"
         required: true
-        default: "8.99.99"
+        default: "0.0.1"
         type: "string"
       skip-publish:
         description: "Skip publish?"
@@ -46,11 +46,18 @@ on:
         default: false
         type: boolean
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   setup:
     name: "Setup"
     runs-on: ubuntu-latest
     steps:
+      - name: Dump all inputs
+        run: echo "${{ toJSON(inputs) }}"
+
       - name: Ensure version of cnquery and cnspec are available
         run: |
           curl -sL --head --fail https://github.com/mondoohq/cnquery/releases/download/v${{ inputs.version }}/cnquery_${{ inputs.version }}_windows_amd64.zip \
@@ -92,6 +99,7 @@ jobs:
 
   msi-build:
     name: "Packaging: Windows MSI"
+    environment: prod
     runs-on: windows-latest
     strategy:
       matrix:
@@ -105,6 +113,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
       - name: Download Distribution
         uses: actions/download-artifact@v4
         with:
@@ -126,28 +135,32 @@ jobs:
           Set-Location -Path '.\packages\msi\'
           ./package.ps1 -version $mondooVersion -arch ${{ matrix.arch }}
 
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.TSIGN_AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.TSIGN_AZURE_TENANT_ID}}
+          subscription-id: ${{ vars.TSIGN_AZURE_SUBSCRIPTION_ID }}
+
       - name: Sign files with Trusted Signing
         uses: azure/trusted-signing-action@v0
         with:
-          azure-tenant-id: ${{ vars.TSIGN_AZURE_TENANT_ID }}
-          azure-client-id: ${{ secrets.TSIGN_AZURE_CLIENT_ID }}
-          azure-client-secret: ${{ secrets.TSIGN_AZURE_CLIENT_SECRET }}
           endpoint: ${{ vars.TSIGN_AZURE_ENDPOINT }}
           trusted-signing-account-name: ${{ vars.TSIGN_ACCOUNT_NAME }}
           # Conditional logic for switching certificate-profile-name type
-          certificate-profile-name: ${{ github.event.inputs.use-test-cert == 'true' && vars.TSIGN_TEST_CERT_PROFILE_NAME || vars.TSIGN_CERT_PROFILE_NAME }}
+          certificate-profile-name: ${{ inputs.use-test-cert == true && vars.TSIGN_TEST_CERT_PROFILE_NAME || vars.TSIGN_CERT_PROFILE_NAME }}
           files: |
             ${{ github.workspace }}\packages\msi\mondoo_${{ matrix.arch }}.msi
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA384
-          exclude-environment-credential: false
+          exclude-environment-credential: true
           exclude-workload-identity-credential: true
           exclude-managed-identity-credential: true
           exclude-shared-token-cache-credential: true
           exclude-visual-studio-credential: true
           exclude-visual-studio-code-credential: true
-          exclude-azure-cli-credential: true
+          exclude-azure-cli-credential: false
           exclude-azure-powershell-credential: true
           exclude-azure-developer-cli-credential: true
           exclude-interactive-browser-credential: true
@@ -277,6 +290,7 @@ jobs:
 
   publish:
     name: "Publish: Releases"
+    if: ${{ inputs.skip-publish == false }}
     strategy:
       matrix:
         arch:

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -96,6 +96,7 @@ jobs:
         with:
           name: dist-${{ matrix.arch }}
           path: dist/${{ matrix.arch }}
+          retention-days: 7
 
   msi-build:
     name: "Packaging: Windows MSI"
@@ -176,6 +177,7 @@ jobs:
         with:
           name: msi-${{ matrix.arch }}
           path: dist/${{ matrix.arch }}
+          retention-days: 7
 
   test-msi-install:
     name: Test Signed Package

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -197,6 +197,7 @@ jobs:
           name: msi-${{ matrix.arch }}
           path: dist
       - name: Verify Signed MSI Status
+        if: ${{ inputs.use-test-cert == false }}
         shell: powershell
         run: |
           $msiFileName = "mondoo_${{ matrix.arch }}.msi"

--- a/.github/workflows/pkg_msi.yaml
+++ b/.github/workflows/pkg_msi.yaml
@@ -64,7 +64,7 @@ jobs:
       matrix:
         arch:
           - amd64
-          - arm64
+#TODO - REENABLE          - arm64
     runs-on: ubuntu-latest
     needs: setup
     steps:
@@ -97,7 +97,7 @@ jobs:
       matrix:
         arch:
           - amd64
-          - arm64
+ #TODO - REENABLE         - arm64
     needs:
       - setup
       - dist-prepare
@@ -137,7 +137,7 @@ jobs:
           # Conditional logic for switching certificate-profile-name type
           certificate-profile-name: ${{ github.event.inputs.use-test-cert == 'true' && vars.TSIGN_TEST_CERT_PROFILE_NAME || vars.TSIGN_CERT_PROFILE_NAME }}
           files: |
-            .\packages\msi\mondoo_${{ matrix.arch }}.msi
+            ${{ github.workspace }}\packages\msi\mondoo_${{ matrix.arch }}.msi
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA384

--- a/README.md
+++ b/README.md
@@ -184,17 +184,17 @@ Mondoo signs Microsoft Windows executables, PowerShell scripts, Linux packages a
 To verify the integrity of the `cnquery` or `cnspec` executable, please use Microsoft's Get-AuthenticodeSignature PowerShell command and compare the Thumbprint.
 
 ```powershell
-PS > $file = ".\mondoo_8.15.0_windows_amd64.msi"
-PS > (Get-AuthenticodeSignature -FilePath $file).SignerCertificate | Format-List
+$file = ".\mondoo_11.66.1_windows_amd64.msi"
+(Get-AuthenticodeSignature -FilePath $file).SignerCertificate | Format-List
 
-Subject      : CN="Mondoo, Inc", O="Mondoo, Inc", L=Cary, S=North Carolina, C=US
-Issuer       : CN=DigiCert Global G3 Code Signing ECC SHA384 2021 CA1, O="DigiCert, Inc.", C=US
-Thumbprint   : EE97D1E3C6CD96E06C47B0233DD7C6CE2684FA50
+Subject      : CN="Mondoo, Inc.", O="Mondoo, Inc.", L=Cary, S=North Carolina, C=US
+Issuer       : CN=Microsoft ID Verified CS EOC CA 01, O=Microsoft Corporation, C=US
+Thumbprint   : 6134EB03311452EFFFA36EFC767F4BEBE29A4107
 FriendlyName :
-NotBefore    : 7/26/2022 12:00:00 AM
-NotAfter     : 8/23/2023 11:59:59 PM
-Extensions   : {System.Security.Cryptography.Oid, System.Security.Cryptography.Oid, System.Security.Cryptography.Oid,
-               System.Security.Cryptography.Oid...}
+NotBefore    : 05/08/2025 14:08:51
+NotAfter     : 08/08/2025 14:08:51
+Extensions   : {System.Security.Cryptography.Oid, System.Security.Cryptography.Oid,
+               System.Security.Cryptography.Oid, System.Security.Cryptography.Oid...}
 ```
 
 To verify the integrity of the Mondoo PowerShell `install.ps1` script, please use Microsoft's Get-AuthenticodeSignature PowerShell command and compare the SignerCertificate.


### PR DESCRIPTION
We were previously using Digicert to sign our MSI packages.  This PR migrates this to use [Azure Trusted Signing](https://azure.microsoft.com/en-us/products/trusted-signing)

The Code Signing page in notion has been updated to reflect this change

- Applied a linter to the workflow
- Refactored signing section
  - Uses `azure/login@v2` to login via OIDC and then `azure/trusted-signing-action@v0` to sign
- added `use-test-cert` input to allow test signing using the non prod certificate, this won't be trusted by anyone but proves the process
- switched windows-2025, preemptive validation before September 1st (windows-latest) cut over.