### PR TITLE
Add workflow guard to block prerelease versions

### DIFF
--- a/.github/workflows/pkg_published_trigger_build_release.yaml
+++ b/.github/workflows/pkg_published_trigger_build_release.yaml
@@ -53,7 +53,7 @@ jobs:
   build-msi:
     uses: ./.github/workflows/pkg_msi.yaml
     secrets: inherit
-    needs: [ parse-inputs ]
+    needs: [ check-version ]
     with:
       version: ${{ needs.parse-inputs.outputs.version }}
       skip-publish: ${{ needs.parse-inputs.outputs.skip-publish == 'true' }}
@@ -61,7 +61,7 @@ jobs:
   build-mondoo-pkgs:
     uses: ./.github/workflows/release_mondoo_pkgs.yaml
     secrets: inherit
-    needs: [ parse-inputs ]
+    needs: [ check-version ]
     with:
       version: ${{ needs.parse-inputs.outputs.version }}
       skip-publish: ${{ needs.parse-inputs.outputs.skip-publish == 'true' }}
@@ -69,14 +69,14 @@ jobs:
   build-macos:
     uses: ./.github/workflows/pkg_macos.yaml
     secrets: inherit
-    needs: [ parse-inputs ]
+    needs: [ check-version ]
     with:
       version: ${{ needs.parse-inputs.outputs.version }}
       skip-publish: ${{ needs.parse-inputs.outputs.skip-publish == 'true' }}
       bucket: ${{ needs.parse-inputs.outputs.bucket }}
   reindex:
     runs-on: ubuntu-latest
-    needs: [ parse-inputs, build-msi, build-mondoo-pkgs ]
+    needs: [ check-version, build-msi, build-mondoo-pkgs ]
     steps:
     # fetch a token for the mondoo-mergebot app
     - name: Generate token

--- a/.github/workflows/pkg_published_trigger_build_release.yaml
+++ b/.github/workflows/pkg_published_trigger_build_release.yaml
@@ -76,7 +76,7 @@ jobs:
       bucket: ${{ needs.parse-inputs.outputs.bucket }}
   reindex:
     runs-on: ubuntu-latest
-    needs: [ check-version, build-msi, build-mondoo-pkgs ]
+    needs: [ check-version, build-msi, build-mondoo-pkgs, build-macos ]
     steps:
     # fetch a token for the mondoo-mergebot app
     - name: Generate token

--- a/.github/workflows/pkg_published_trigger_build_release.yaml
+++ b/.github/workflows/pkg_published_trigger_build_release.yaml
@@ -36,6 +36,20 @@ jobs:
       skip-publish: ${{ inputs.skip-publish }}
       version: ${{ inputs.version }}
       bucket: ${{ inputs.bucket }}
+
+  check-version:
+    needs: [parse-inputs]
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          VERSION="${{ needs.parse-inputs.outputs.version }}"
+          echo "Checking version: $VERSION"
+          if [[ "$VERSION" == *"-"* ]]; then
+            echo "❌ Prerelease versions are not allowed ($VERSION)"
+            exit 1
+          fi
+          echo "✅ Version $VERSION is allowed"
+
   build-msi:
     uses: ./.github/workflows/pkg_msi.yaml
     secrets: inherit


### PR DESCRIPTION
This PR adds a check-version job to the workflow that prevents builds from running for prerelease versions (any version containing a - in the string, e.g., 1.2.3-beta, 1.2.3-alpha, 1.2.3-rc).

**Changes**

- Added check-version job after parse-inputs:
- Downstream jobs (e.g., build-msi) now need: check-version, ensuring that the workflow stops immediately if the version is a prerelease.
- This centralizes version validation so individual jobs do not need to duplicate the check.

**Benefits**

- Prevents accidental builds or releases from non-final versions.

- Stops the workflow early to save time and resources.

_NOTE_
Debian and Windows only support version numbers, adding '-pre1' for example will break the package creation, so further downstream changes will be required if you do want to these 