### PR TITLE
add separate script that deploys scheduled task on windows

### DIFF
--- a/.github/workflows/sign_powershell.yml
+++ b/.github/workflows/sign_powershell.yml
@@ -26,6 +26,7 @@ on:
       - "download.ps1"
       - "powershell/Mondoo.Installer/Mondoo.Installer.psm1"
       - "powershell/Mondoo.Installer/Mondoo.Installer.psd1"
+      - "powershell/Mondoo.Installer/Mondoo.Installer.ScheduledUpdateTask.ps1"
 
 # Once Azure Signing is live, remember to delete
 # - "secrets.SM_CLIENT_CERT_FILE_B64
@@ -64,6 +65,7 @@ jobs:
             download.ps1
             powershell/Mondoo.Installer/Mondoo.Installer.psm1
             powershell/Mondoo.Installer/Mondoo.Installer.psd1
+            powershell/Mondoo.Installer/Mondoo.Installer.ScheduledUpdateTask.ps1
 
       - name: Azure login
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
@@ -84,6 +86,7 @@ jobs:
             ${{ github.workspace }}\download.ps1
             ${{ github.workspace }}\powershell\Mondoo.Installer\Mondoo.Installer.psm1
             ${{ github.workspace }}\powershell\Mondoo.Installer\Mondoo.Installer.psd1
+            ${{ github.workspace }}\powershell\Mondoo.Installer\Mondoo.Installer.ScheduledUpdateTask.ps1
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA384
@@ -108,6 +111,7 @@ jobs:
             ${{ github.workspace }}\download.ps1
             ${{ github.workspace }}\powershell\Mondoo.Installer\Mondoo.Installer.psm1
             ${{ github.workspace }}\powershell\Mondoo.Installer\Mondoo.Installer.psd1
+            ${{ github.workspace }}\powershell\Mondoo.Installer\Mondoo.Installer.ScheduledUpdateTask.ps1
           retention-days: 14
 
       - name: Commit changes
@@ -126,5 +130,6 @@ jobs:
           git add download.ps1
           git add powershell/Mondoo.Installer/Mondoo.Installer.psm1
           git add powershell/Mondoo.Installer/Mondoo.Installer.psd1
+          git add powershell/Mondoo.Installer/Mondoo.Installer.ScheduledUpdateTask.ps1
           git commit -m "Sign powershell scripts"
           git push

--- a/powershell/Mondoo.Installer/Mondoo.Installer.ScheduledUpdateTask.ps1
+++ b/powershell/Mondoo.Installer/Mondoo.Installer.ScheduledUpdateTask.ps1
@@ -1,0 +1,119 @@
+#Requires -RunAsAdministrator
+param(
+    [string] $Product    = 'mondoo',
+    [string] $Path       = 'C:\Program Files\Mondoo\',
+    [string] $Time       = '12:00',    # Time of day the task runs
+    [int]    $Interval   = 1,          # Run every N days
+    [string] $Proxy      = '',         # Optional: http://1.1.1.1:3128
+    [string] $Service    = 'enable',   # Whether to pass -Service enable
+    [string] $Annotation = '',         # Optional mondoo annotations
+    [string] $Name       = '',         # Optional asset name
+    [string] $TaskName   = $null,      # Optional override
+    [string] $TaskPath   = $null       # Optional override (folder under \)
+)
+
+if (-not $TaskName) {
+    $TaskName = "${Product}Updater"    # e.g. mondooUpdater
+}
+if (-not $TaskPath) {
+    $TaskPath = $Product               # e.g. \mondoo
+}
+
+function NewScheduledTaskFolder {
+    param(
+        [string] $TaskPath
+    )
+
+    $ErrorActionPreference = "Stop"
+    $scheduleObject = New-Object -ComObject schedule.service
+    $scheduleObject.Connect()
+    $rootFolder = $scheduleObject.GetFolder("\")
+    try {
+        $null = $scheduleObject.GetFolder($TaskPath)
+    }
+    catch {
+        $null = $rootFolder.CreateFolder($TaskPath)
+    }
+    finally {
+        $ErrorActionPreference = "Continue"
+    }
+}
+
+function Create-MondooUpdateScheduledTask {
+    param(
+        [string] $TaskName,
+        [string] $TaskPath
+    )
+
+    Write-Host " * Creating Mondoo update task '$TaskName' in '\$TaskPath'"
+
+    NewScheduledTaskFolder -TaskPath $TaskPath
+
+    # Build the command that the scheduled task will execute
+    $command = @(
+        '[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;'
+        '$wc = New-Object Net.Webclient;'
+    )
+
+    if (-not [string]::IsNullOrEmpty($Proxy)) {
+        $command += '$wc.proxy = New-Object System.Net.WebProxy(' + "'$Proxy'" + ');'
+    }
+
+    $command += 'iex ($wc.DownloadString(' + "'https://install.mondoo.com/ps1'" + '));'
+
+    # Build the Install-Mondoo command (same logic as in the original script)
+    $installCmd = @("Install-Mondoo")
+    $installCmd += "-Product $Product"
+    $installCmd += "-Path '$Path'"
+
+    if ($Service.ToLower() -eq 'enable' -and $Product.ToLower() -eq 'mondoo') {
+        $installCmd += "-Service enable"
+    }
+    if (-not [string]::IsNullOrEmpty($Annotation)) {
+        $installCmd += "-Annotation '$Annotation'"
+    }
+    if (-not [string]::IsNullOrEmpty($Name)) {
+        $installCmd += "-Name $Name"
+    }
+    if (-not [string]::IsNullOrEmpty($Proxy)) {
+        $installCmd += "-Proxy $Proxy"
+    }
+
+    # Always create the task as an update task
+    $installCmd += "-UpdateTask enable -Time $Time -Interval $Interval;"
+
+    $command += ($installCmd -join ' ')
+
+    # Wrap everything into a single -Command argument for PowerShell.exe
+    $taskArgument = "-NoProfile -WindowStyle Hidden -ExecutionPolicy RemoteSigned -Command `"&{ $($command -join ' ') }`""
+
+    Write-Host " * Scheduled Task argument:"
+    Write-Host "   $taskArgument"
+    Write-Host ""
+
+    # Define the scheduled task pieces
+    $action    = New-ScheduledTaskAction  -Execute 'Powershell.exe' -Argument $taskArgument
+    $trigger   = New-ScheduledTaskTrigger -Daily -DaysInterval $Interval -At $Time
+    $principal = New-ScheduledTaskPrincipal -GroupId "NT AUTHORITY\SYSTEM" -RunLevel Highest
+    $settings  = New-ScheduledTaskSettingsSet -Compatibility Win8
+
+    Register-ScheduledTask -Action $action -Settings $settings -Trigger $trigger `
+        -TaskName $TaskName -Description "$Product Updater Task" -TaskPath $TaskPath `
+        -Principal $principal
+
+    if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
+        Write-Host "* $Product Updater Task '$TaskName' installed successfully." -ForegroundColor DarkGreen
+    }
+    else {
+        Write-Error "Installation of $Product Updater Task '$TaskName' failed."
+    }
+}
+
+# Remove an existing task with the same name (if present)
+$existing = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if ($existing) {
+    Write-Host " * Existing task '$TaskName' found. Removing it first..."
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+}
+
+Create-MondooUpdateScheduledTask -TaskName $TaskName -TaskPath $TaskPath

--- a/powershell/Mondoo.Installer/Mondoo.Installer.ScheduledUpdateTask.ps1
+++ b/powershell/Mondoo.Installer/Mondoo.Installer.ScheduledUpdateTask.ps1
@@ -1,3 +1,5 @@
+# Copyright (c) Mondoo, Inc.
+# SPDX-License-Identifier: BUSL-1.1
 #Requires -RunAsAdministrator
 param(
     [string] $Product    = 'mondoo',


### PR DESCRIPTION
Sometimes Sentinel1 blocks the deployment of the updatetask in the main installer.ps1
We add this optional script to be able to execute this individually to decrease the chance of S1 blocking it.

we also need to sign this script to be able to create an exclusion for it in S1